### PR TITLE
fix(docs): address review comments on verification PRs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: "20"
 
       - name: Install Mintlify CLI
-        run: npm i -g mintlify@latest
+        run: npm i -g mintlify@4.2.835
 
       - name: Build Mintlify site
         working-directory: docs-site

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Check nav completeness
         run: uv run python docs-site/scripts/check_nav_completeness.py
 
+      - name: Verify docs (broken links, orphans, stubs)
+        run: uv run python docs-site/scripts/verify_docs.py
+
       - name: Set up Node for markdownlint
         uses: actions/setup-node@v4
         with:

--- a/docs-site/scripts/verify_browser.py
+++ b/docs-site/scripts/verify_browser.py
@@ -1,6 +1,6 @@
 """Headless browser verification for remaining Mintlify tasks (1.9,2.4,2.5,7.2,7.4,7.8,7.11).
-Runs `npx mintlify dev --port 3001` and checks via Playwright if available,
-otherwise falls back to curl checks. Exits 0 on pass, 1 on fail.
+Runs `npx mintlify dev --port 3001` and checks the page via an HTTP request
+using `requests`. Exits 0 on pass, 1 on fail.
 """
 import subprocess, time, sys, os, signal
 


### PR DESCRIPTION
Addresses follow-up review on #31/#32 (Greptile + docstring).

**Fixes:**
- `docs-site/scripts/verify_browser.py` — docstring now correctly says `checks the page via an HTTP request using requests` (was claiming Playwright/curl fallback that was never implemented)
- `.github/workflows/docs-ci.yml` — add `verify_docs.py` step (broken links/orphans/stubs) so Docs CI actually fails on dead links (was only frontmatter/nav/markdownlint)
- `.github/workflows/deploy-docs.yml` — pin `mintlify@4.2.835` instead of `@latest` for reproducible supply-chain (was mutable tag with Pages write perms)

Verified: `uv run python docs-site/scripts/verify_docs.py` PASS, ruff/ty clean on touched files.

## Summary by Sourcery

Improve documentation workflow reliability by validating documentation integrity in CI, pinning the deployment tool version, and correcting verification script documentation.

Bug Fixes:
- Correct the browser verification script documentation to accurately describe its HTTP-based page check.

Enhancements:
- Add automated documentation verification for broken links, orphaned pages, and stubs to Docs CI.
- Pin the Mintlify CLI version used for documentation deployment to ensure reproducible builds.

CI:
- Run documentation integrity checks as part of the Docs CI workflow.

Deployment:
- Use a fixed Mintlify CLI version during documentation deployment.