### PR TITLE
fix(docs): cleanup timeout escapes in verify_browser

### DIFF
--- a/docs-site/scripts/verify_browser.py
+++ b/docs-site/scripts/verify_browser.py
@@ -3,6 +3,7 @@ Runs `npx mintlify dev --port 3001` and checks the page via an HTTP request
 using `requests`. Exits 0 on pass, 1 on fail.
 """
 
+import contextlib
 import subprocess
 import sys
 import os
@@ -78,17 +79,14 @@ def main() -> int:
         return 1
     finally:
         if proc is not None:
-            try:
+            with contextlib.suppress(ProcessLookupError):
                 os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-            except Exception:
-                pass
             try:
                 proc.wait(timeout=5)
-            except Exception:
-                try:
+            except subprocess.TimeoutExpired:
+                with contextlib.suppress(ProcessLookupError):
                     os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-                except Exception:
-                    pass
+                proc.wait()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Verifies and fixes Greptile P2 on PR #32.

**Issue:** If the Mintlify process tree takes longer than 5s to stop after SIGTERM, the unhandled `TimeoutExpired` replaces the verifier's documented exit result with a traceback and leaves the dev server running on port 3001.

**Fix:** Match suggested patch — `proc.wait(timeout=5)` now caught as `TimeoutExpired`, then `SIGKILL` + `proc.wait()` to reap. `ProcessLookupError` suppressed via `contextlib.suppress` for both kills (was broad `Exception` before PR #36, now precise).

**Verified:**
- PR #32 original at `4decda0` had bare `proc.wait(timeout=5)` with no handler (bug reproduced)
- Current `main` at `0141c8a` had partial fix (catch `Exception` + SIGKILL but no re-wait, broad except)
- This PR makes the suggested handling exact and adds re-wait, so exit code is preserved and port is freed

**Blast radius:** `verify_browser.py` only — Docs CI/Deploy workflows unaffected, `ruff` 8 pre-existing TRY003 remain, `ty` clean.

## Summary by Sourcery

Make browser verification cleanup reliably terminate and reap timed-out processes.

Bug Fixes:
- Ensure the browser verification process is forcefully terminated and reaped when graceful shutdown exceeds its timeout, preserving the verifier’s documented exit status and freeing the development port.

Enhancements:
- Use precise process-exception handling when terminating the browser verification process instead of broad exception suppression.