### PR TITLE
fix(docs): require docs.json and mint.json identity when both exist

### DIFF
--- a/docs-site/scripts/check_nav_completeness.py
+++ b/docs-site/scripts/check_nav_completeness.py
@@ -15,8 +15,13 @@ import sys
 from pathlib import Path
 
 DOCS_ROOT = Path(__file__).resolve().parents[1]
-# Mintlify 4.x uses docs.json, 3.x used mint.json — support both
-MINT_JSON = DOCS_ROOT / "docs.json" if (DOCS_ROOT / "docs.json").exists() else DOCS_ROOT / "mint.json"
+# Mintlify 4.x uses docs.json, 3.x used mint.json — support both, but require
+# identity when both exist so legacy 3.x builds don't silently diverge.
+DOCS_JSON = DOCS_ROOT / "docs.json"
+LEGACY_MINT_JSON = DOCS_ROOT / "mint.json"
+if DOCS_JSON.exists() and LEGACY_MINT_JSON.exists() and DOCS_JSON.read_bytes() != LEGACY_MINT_JSON.read_bytes():
+    raise SystemExit("FAIL: docs.json and mint.json must be identical")
+MINT_JSON = DOCS_JSON if DOCS_JSON.exists() else LEGACY_MINT_JSON
 
 
 def load_nav_entries() -> list[str]:

--- a/docs-site/scripts/verify_docs.py
+++ b/docs-site/scripts/verify_docs.py
@@ -21,8 +21,13 @@ from pathlib import Path
 import yaml  # pyyaml — already in repo
 
 DOCS_ROOT = Path(__file__).resolve().parents[1]
-# Mintlify 4.x uses docs.json, 3.x used mint.json — support both
-MINT_JSON = DOCS_ROOT / "docs.json" if (DOCS_ROOT / "docs.json").exists() else DOCS_ROOT / "mint.json"
+# Mintlify 4.x uses docs.json, 3.x used mint.json — support both, but require
+# identity when both exist so legacy 3.x builds don't silently diverge.
+DOCS_JSON = DOCS_ROOT / "docs.json"
+LEGACY_MINT_JSON = DOCS_ROOT / "mint.json"
+if DOCS_JSON.exists() and LEGACY_MINT_JSON.exists() and DOCS_JSON.read_bytes() != LEGACY_MINT_JSON.read_bytes():
+    raise SystemExit("FAIL: docs.json and mint.json must be identical")
+MINT_JSON = DOCS_JSON if DOCS_JSON.exists() else LEGACY_MINT_JSON
 
 # ponytail: substring scan is intentional — catches "STUB:", "TODO:" in any case.
 STUB_RE = re.compile(r"\b(TODO|lorem|stub)\b", re.IGNORECASE)


### PR DESCRIPTION
Fixes Sourcery approval pending on #38.

**Issue:** When both `docs.json` (Mintlify 4.x) and `mint.json` (3.x legacy) exist and diverge, both validators always read `docs.json` and silently ignore the legacy config, so they can pass while the legacy build is invalid.

**Fix:**
- `check_nav_completeness.py:18` and `verify_docs.py:24`: if both files exist and bytes differ → `raise SystemExit("FAIL: docs.json and mint.json must be identical")`, else select canonical. Prevents silent divergence.

**Verified:** `cmp docs.json mint.json` → identical YES, `verify_docs.py` PASS, `check_nav_completeness.py` PASS. If diverge, both scripts now FAIL as intended.

## Summary by Sourcery

Ensure documentation validators reject conflicting Mintlify configuration files.

Bug Fixes:
- Prevent documentation validation from silently accepting divergent docs.json and mint.json configurations.

Enhancements:
- Require docs.json and mint.json to be byte-identical when both are present while continuing to support either configuration format independently.