### PR TITLE
fix(docs): set theme to mint for docs.json 4.x schema

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "prism",
+  "theme": "mint",
   "name": "AgentNexus FastAPI",
   "description": "Production LangChain + FastAPI platform for legal AI agents.",
   "colors": {

--- a/docs-site/mint.json
+++ b/docs-site/mint.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "prism",
+  "theme": "mint",
   "name": "AgentNexus FastAPI",
   "description": "Production LangChain + FastAPI platform for legal AI agents.",
   "colors": {


### PR DESCRIPTION
Fixes second discriminator error on `bunx mintlify@4.2.835 dev --port 3001`:

**Error:**
```
#.theme: Invalid discriminator value. Expected 'mint' | 'maple' | 'palm' | 'willow' | 'linden' | 'almond' | 'aspen' | 'luma' | 'sequoia'
```
— was `prism` (valid for old `mint.json` 3.x schema `venus|quill|prism` but not for 4.x `docs.json`).

**Fix:**
- `docs-site/docs.json` + `mint.json` both `prism` → `mint` (valid for 4.2.835, keeps files identical per dual-config check)
- Keeps `navigation: [...]` array and `docs.json` copy for 4.x

**Verified:** `verify_docs.py` PASS, `warn: incorrect peer dependency react@19.2.3` remains (harmless).

## Summary by Sourcery

Bug Fixes:
- Update the documentation theme configuration to use the `mint` value supported by the 4.x schema.