### PR TITLE
fix(docs): docs.json navigation object + integrations for 4.x

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -13,7 +13,8 @@
     "dark": "/images/logo-dark.svg"
   },
   "favicon": "/images/favicon.svg",
-  "navigation": [
+  "navigation": {
+    "groups": [
       {
         "group": "Get Started",
         "pages": [
@@ -77,7 +78,8 @@
       { "group": "Deployment", "pages": ["deployment/index"] },
       { "group": "Development", "pages": ["development/index"] },
       { "group": "Resources", "pages": ["resources/security", "resources/faq"] }
-    ],
+    ]
+  },
   "topbarLinks": [
     { "name": "API Reference", "url": "/api-reference" }
   ],
@@ -95,9 +97,7 @@
       "description": "Production documentation for the AgentNexus LangChain-FastAPI legal AI platform."
     }
   },
-  "integrations": {
-    "options": {}
-  },
+  "integrations": {},
   "redirects": [
     { "source": "/security", "destination": "/resources/security" }
   ]


### PR DESCRIPTION
Fixes terminal 1:12-43:

**Terminal errors:**
- `bash: cd: docs-site: No such file or directory` — was already in `docs-site`, so `cd docs-site` tries `docs-site/docs-site`. Run from repo root: `bunx mintlify@4.2.835 dev --port 3001` (uses `docs.json` at `docs-site/`) or `cd docs-site && bunx mintlify dev`.
- `#.navigation: Invalid type. Expected object, received array` (x8) + `#.integrations: Unrecognized key 'options'` — `docs.json` had `navigation: [...]` array and `integrations: {options:{}}`.

**Fix:**
- `docs-site/docs.json`: `navigation` `[...]` → `{groups:[...]}` per 4.2.835 `docs.json` schema (was array which triggered 8x object errors)
- `integrations: {options:{}}` → `{}`

**Verified:** `verify_docs.py` PASS, `bunx mintlify@4.2.835 dev --port 3001` no longer throws `Invalid docs.json` prebuild — now shows `preparing local preview...` (first run 60-90s to install Next.js deps, `react@19.2.3` peer warning is harmless).

## Summary by Sourcery

Bug Fixes:
- Fix the documentation site configuration so Mintlify 4.x accepts the navigation and integrations settings without prebuild validation errors.