### PR TITLE
refactor(celery): remove RedisClientProtocol and datamodels, consolidate into single module

### DIFF
--- a/src/app/connections/celery.py
+++ b/src/app/connections/celery.py
@@ -1,10 +1,33 @@
-"""Celery connection and production reliability configuration."""
+"""Celery connection and production reliability configuration — single source.
 
+Combined from the previous split to remove drift and import cycles:
+- `celery_task_names.py` remains the single definition site for task-name constants
+  (imported here, so one copy serves the app, registry, and tests)
+- `celery_reliability.py` → functional helpers (`Redis` from `redis.asyncio`, plain
+  dicts, `RateLimitResult` as `BaseModel`) — now inlined
+- `celery.py` → `ResilientTask`, `create_celery_app`, exchanges, routes, signals
+- `celery_registry.py` → typed dispatch `CeleryTaskRegistry` + `TypedCeleryTask` — now inlined
+
+`celery_reliability.py` and `celery_registry.py` remain as thin shims
+(`from app.connections.celery import ...`) for one release so existing imports
+keep working. New code must import from `app.connections.celery` directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
 import time
-from typing import Any, ClassVar, cast, override
+from collections.abc import Awaitable
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from functools import cache
+from importlib import import_module
+from inspect import isawaitable
+from typing import TYPE_CHECKING, Literal, TypedDict, cast, override
 
 import opentelemetry.trace as otel_trace
 from celery import Celery, Task
+from celery.exceptions import CeleryError
 from celery.schedules import crontab
 from celery.signals import (
     after_task_publish,
@@ -15,20 +38,23 @@ from celery.signals import (
 )
 from kombu import Exchange, Queue
 from opentelemetry import metrics
-from redis.asyncio import Redis
+from pydantic import BaseModel, ValidationError
 
 from app.config import get_settings
 from app.connections.redis import create_redis_client
 from app.utils import logger
+from app.utils.cache import Redis
+from app.utils.json_serializer import from_json, to_json_str
 
-from .celery_reliability import (
-    RedisClientProtocol,
-    acquire_idempotency_lock,
-    mark_idempotency_completed,
-    mark_idempotency_failed_permanently,
-    release_idempotency_processing_lock,
-    run_with_circuit_breaker,
-)
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable, Coroutine
+    from typing import Any, ClassVar
+
+    from app.config.settings import Settings
+
+# ---------------------------------------------------------------------------
+# Task-name constants — imported from single definition site
+# ---------------------------------------------------------------------------
 from .celery_task_names import (
     BILLING_DUNNING,
     BILLING_INVOICE_GENERATION,
@@ -39,6 +65,637 @@ from .celery_task_names import (
     INGESTION_TASK_NAMES,
     TASK_DECLARING_MODULES,
 )
+
+# ---------------------------------------------------------------------------
+# Reliability helpers — functional, plain dicts, Redis from redis.asyncio
+# ---------------------------------------------------------------------------
+
+type JsonValue = str | int | float | bool | list[JsonValue] | dict[str, JsonValue] | None
+type RedisOperationResult = object | Awaitable[object]
+
+type IdempotencyStatus = Literal["processing", "completed", "failed_permanent"]
+type JsonMetadata = dict[str, JsonValue]
+
+PROCESSING_STATUS: IdempotencyStatus = "processing"
+COMPLETED_STATUS: IdempotencyStatus = "completed"
+FAILED_PERMANENT_STATUS: IdempotencyStatus = "failed_permanent"
+
+IDEMPOTENCY_NAMESPACE = "celery:idempotency"
+CIRCUIT_BREAKER_NAMESPACE = "celery:circuit"
+
+
+class CircuitBreakerSnapshot(TypedDict):
+    state: str
+    failures: int
+    opened_at: float | None
+
+
+class CircuitBreakerOpenError(RuntimeError):
+    """Raised when the circuit breaker is open."""
+
+
+def run_redis_call[T](value: T | Awaitable[T]) -> T:
+    """Resolve either a direct Redis result or an awaitable returned by async Redis."""
+    if isawaitable(value):
+        return asyncio.run(cast("Coroutine[object, object, T]", value))
+    return value
+
+
+def build_idempotency_key(
+    idempotency_key: str,
+    *,
+    namespace: str = IDEMPOTENCY_NAMESPACE,
+) -> str:
+    return f"{namespace}:{idempotency_key}"
+
+
+def serialize_idempotency_record(
+    status: IdempotencyStatus,
+    *,
+    task_id: str | None = None,
+    updated_at: str | None = None,
+    metadata: JsonMetadata | None = None,
+) -> str:
+    payload: dict[str, object] = {
+        "status": status,
+        "task_id": task_id,
+        "updated_at": updated_at if updated_at is not None else datetime.now(tz=UTC).isoformat(),
+        "metadata": metadata or {},
+    }
+    return to_json_str(payload)
+
+
+def acquire_idempotency_lock(
+    redis_client: Redis,
+    idempotency_key: str,
+    *,
+    task_id: str | None = None,
+    ttl_seconds: int = 86400,
+    metadata: JsonMetadata | None = None,
+    namespace: str = IDEMPOTENCY_NAMESPACE,
+) -> bool:
+    """Acquire a processing lock for a business operation."""
+    return bool(
+        run_redis_call(
+            redis_client.set(
+                name=build_idempotency_key(idempotency_key, namespace=namespace),
+                value=serialize_idempotency_record(
+                    PROCESSING_STATUS,
+                    task_id=task_id,
+                    metadata=metadata,
+                ),
+                ex=ttl_seconds,
+                nx=True,
+            )
+        )
+    )
+
+
+def mark_idempotency_completed(
+    redis_client: Redis,
+    idempotency_key: str,
+    *,
+    task_id: str | None = None,
+    ttl_seconds: int = 86400,
+    metadata: JsonMetadata | None = None,
+    namespace: str = IDEMPOTENCY_NAMESPACE,
+) -> None:
+    run_redis_call(
+        redis_client.set(
+            name=build_idempotency_key(idempotency_key, namespace=namespace),
+            value=serialize_idempotency_record(
+                COMPLETED_STATUS,
+                task_id=task_id,
+                metadata=metadata,
+            ),
+            ex=ttl_seconds,
+        )
+    )
+
+
+def mark_idempotency_failed_permanently(
+    redis_client: Redis,
+    idempotency_key: str,
+    *,
+    task_id: str | None = None,
+    ttl_seconds: int = 86400,
+    metadata: JsonMetadata | None = None,
+    namespace: str = IDEMPOTENCY_NAMESPACE,
+) -> None:
+    run_redis_call(
+        redis_client.set(
+            name=build_idempotency_key(idempotency_key, namespace=namespace),
+            value=serialize_idempotency_record(
+                FAILED_PERMANENT_STATUS,
+                task_id=task_id,
+                metadata=metadata,
+            ),
+            ex=ttl_seconds,
+        )
+    )
+
+
+def release_idempotency_processing_lock(
+    redis_client: Redis,
+    idempotency_key: str,
+    *,
+    namespace: str = IDEMPOTENCY_NAMESPACE,
+) -> None:
+    """Release the processing lock so a later retry can acquire it again."""
+    run_redis_call(redis_client.delete(build_idempotency_key(idempotency_key, namespace=namespace)))
+
+
+def get_idempotency_status(
+    redis_client: Redis,
+    idempotency_key: str,
+    *,
+    namespace: str = IDEMPOTENCY_NAMESPACE,
+) -> IdempotencyStatus | None:
+    payload: str | None = cast(
+        "str | None",
+        run_redis_call(
+            redis_client.get(build_idempotency_key(idempotency_key, namespace=namespace))
+        ),
+    )
+    if not payload:
+        return None
+    data = cast("dict[str, object]", from_json(payload))
+    status = data.get("status")
+    if status in {PROCESSING_STATUS, COMPLETED_STATUS, FAILED_PERMANENT_STATUS}:
+        return cast("IdempotencyStatus", status)
+    return None
+
+
+def build_circuit_breaker_key(
+    name: str,
+    *,
+    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
+) -> str:
+    return f"{namespace}:{name}"
+
+
+def _default_circuit_snapshot() -> CircuitBreakerSnapshot:
+    return {"state": "closed", "failures": 0, "opened_at": None}
+
+
+def get_circuit_breaker_state(
+    redis_client: Redis,
+    name: str,
+    *,
+    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
+) -> CircuitBreakerSnapshot:
+    payload = cast(
+        "str | None",
+        run_redis_call(redis_client.get(build_circuit_breaker_key(name, namespace=namespace))),
+    )
+    if not payload:
+        return _default_circuit_snapshot()
+    data = cast("dict[str, object]", from_json(payload))
+    failures_raw = data.get("failures", 0)
+    return {
+        "state": str(data.get("state", "closed")),
+        "failures": failures_raw if isinstance(failures_raw, int) else 0,
+        "opened_at": cast("float | None", data.get("opened_at")),
+    }
+
+
+def set_circuit_breaker_state(
+    redis_client: Redis,
+    name: str,
+    state: CircuitBreakerSnapshot,
+    *,
+    recovery_timeout_seconds: int,
+    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
+) -> None:
+    run_redis_call(
+        redis_client.set(
+            name=build_circuit_breaker_key(name, namespace=namespace),
+            value=to_json_str(state),
+            ex=recovery_timeout_seconds * 2,
+        )
+    )
+
+
+def is_circuit_breaker_open(
+    redis_client: Redis,
+    name: str,
+    *,
+    recovery_timeout_seconds: int,
+    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
+) -> bool:
+    state = get_circuit_breaker_state(redis_client, name, namespace=namespace)
+    if state["state"] != "open" or state["opened_at"] is None:
+        return False
+    elapsed = time.time() - state["opened_at"]
+    if elapsed < recovery_timeout_seconds:
+        return True
+    set_circuit_breaker_state(
+        redis_client,
+        name,
+        {"state": "half_open", "failures": state["failures"], "opened_at": state["opened_at"]},
+        recovery_timeout_seconds=recovery_timeout_seconds,
+        namespace=namespace,
+    )
+    return False
+
+
+def record_circuit_breaker_success(
+    redis_client: Redis,
+    name: str,
+    *,
+    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
+) -> None:
+    run_redis_call(redis_client.delete(build_circuit_breaker_key(name, namespace=namespace)))
+
+
+def record_circuit_breaker_failure(
+    redis_client: Redis,
+    name: str,
+    *,
+    failure_threshold: int,
+    recovery_timeout_seconds: int,
+    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
+) -> None:
+    state = get_circuit_breaker_state(redis_client, name, namespace=namespace)
+    failures = state["failures"] + 1
+    if failures >= failure_threshold:
+        set_circuit_breaker_state(
+            redis_client,
+            name,
+            {"state": "open", "failures": failures, "opened_at": time.time()},
+            recovery_timeout_seconds=recovery_timeout_seconds,
+            namespace=namespace,
+        )
+        return
+    set_circuit_breaker_state(
+        redis_client,
+        name,
+        {"state": "closed", "failures": failures, "opened_at": None},
+        recovery_timeout_seconds=recovery_timeout_seconds,
+        namespace=namespace,
+    )
+
+
+def run_with_circuit_breaker[T](
+    redis_client: Redis,
+    name: str,
+    operation: Callable[[], T],
+    *,
+    failure_threshold: int,
+    recovery_timeout_seconds: int,
+    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
+) -> T:
+    """Execute an operation unless the circuit breaker is open."""
+    if is_circuit_breaker_open(
+        redis_client,
+        name,
+        recovery_timeout_seconds=recovery_timeout_seconds,
+        namespace=namespace,
+    ):
+        msg = f"Circuit breaker open for '{name}'"
+        raise CircuitBreakerOpenError(msg)
+    try:
+        result = operation()
+    except Exception:
+        record_circuit_breaker_failure(
+            redis_client,
+            name,
+            failure_threshold=failure_threshold,
+            recovery_timeout_seconds=recovery_timeout_seconds,
+            namespace=namespace,
+        )
+        raise
+    record_circuit_breaker_success(redis_client, name, namespace=namespace)
+    return result
+
+
+class ReliabilitySystem:
+    """Unified reliability base for Celery tasks."""
+
+    def __init__(
+        self,
+        redis_client: Redis,
+        *,
+        circuit_breaker_name: str,
+        failure_threshold: int | None = None,
+        recovery_timeout_seconds: int | None = None,
+        idempotency_ttl_seconds: int | None = None,
+        settings: Settings | None = None,
+    ) -> None:
+        self._redis = redis_client
+        self._circuit_breaker_name = circuit_breaker_name
+        if settings is None:
+            from app.config.settings import get_settings  # noqa: PLC0415
+
+            settings = get_settings()
+        self._failure_threshold = (
+            failure_threshold
+            if failure_threshold is not None
+            else settings.CELERY_CIRCUIT_BREAKER_FAILURE_THRESHOLD
+        )
+        self._recovery_timeout = (
+            recovery_timeout_seconds
+            if recovery_timeout_seconds is not None
+            else settings.CELERY_CIRCUIT_BREAKER_RECOVERY_TIMEOUT
+        )
+        self._default_idempotency_ttl = (
+            idempotency_ttl_seconds
+            if idempotency_ttl_seconds is not None
+            else settings.CELERY_IDEMPOTENCY_TTL_SECONDS
+        )
+        self._validate_config()
+
+    def _validate_config(self) -> None:
+        if self._failure_threshold < 1:
+            msg = f"failure_threshold must be >= 1, got {self._failure_threshold}"
+            raise ValueError(msg)
+        if self._recovery_timeout < 1:
+            msg = f"recovery_timeout_seconds must be >= 1, got {self._recovery_timeout}"
+            raise ValueError(msg)
+        if self._default_idempotency_ttl < 1:
+            msg = f"idempotency_ttl_seconds must be >= 1, got {self._default_idempotency_ttl}"
+            raise ValueError(msg)
+
+    def check_circuit_breaker(self) -> None:
+        if is_circuit_breaker_open(
+            self._redis,
+            self._circuit_breaker_name,
+            recovery_timeout_seconds=self._recovery_timeout,
+        ):
+            msg = f"Circuit breaker '{self._circuit_breaker_name}' is open"
+            raise CircuitBreakerOpenError(msg)
+
+    def record_success(self) -> None:
+        record_circuit_breaker_success(self._redis, self._circuit_breaker_name)
+
+    def record_failure(self) -> None:
+        record_circuit_breaker_failure(
+            self._redis,
+            self._circuit_breaker_name,
+            failure_threshold=self._failure_threshold,
+            recovery_timeout_seconds=self._recovery_timeout,
+        )
+
+    def get_idempotency_status(self, idempotency_key: str) -> IdempotencyStatus | None:
+        return get_idempotency_status(self._redis, idempotency_key)
+
+    @property
+    def default_idempotency_ttl(self) -> int:
+        return self._default_idempotency_ttl
+
+
+class IdempotencyLockError(RuntimeError):
+    """Raised when idempotency lock cannot be acquired."""
+
+
+@asynccontextmanager
+async def idempotency_manager(
+    redis_client: Redis,
+    idempotency_key: str,
+    *,
+    task_id: str | None = None,
+    ttl_seconds: int = 86400,
+    metadata: JsonMetadata | None = None,
+    retryable_exceptions: tuple[type[Exception], ...] = (),
+) -> AsyncIterator[None]:
+    """Context manager for idempotency lock lifecycle."""
+    from loguru import logger  # noqa: PLC0415
+
+    acquired = acquire_idempotency_lock(
+        redis_client,
+        idempotency_key,
+        task_id=task_id,
+        ttl_seconds=ttl_seconds,
+        metadata=metadata,
+    )
+    if not acquired:
+        logger.warning(
+            "Idempotency lock already held",
+            idempotency_key=idempotency_key,
+            task_id=task_id,
+        )
+        msg = f"Operation '{idempotency_key}' is already processing"
+        raise IdempotencyLockError(msg)
+    logger.info(
+        "Idempotency lock acquired",
+        idempotency_key=idempotency_key,
+        task_id=task_id,
+        ttl_seconds=ttl_seconds,
+    )
+    try:
+        yield
+        mark_idempotency_completed(
+            redis_client,
+            idempotency_key,
+            task_id=task_id,
+            ttl_seconds=ttl_seconds,
+            metadata=metadata,
+        )
+        logger.info(
+            "Operation completed successfully",
+            idempotency_key=idempotency_key,
+            task_id=task_id,
+        )
+    except Exception as exc:
+        is_retryable = isinstance(exc, retryable_exceptions) if retryable_exceptions else False
+        if is_retryable:
+            release_idempotency_processing_lock(redis_client, idempotency_key)
+            logger.warning(
+                "Retryable failure, released processing lock",
+                idempotency_key=idempotency_key,
+                task_id=task_id,
+                exception_type=type(exc).__name__,
+            )
+        else:
+            mark_idempotency_failed_permanently(
+                redis_client,
+                idempotency_key,
+                task_id=task_id,
+                ttl_seconds=ttl_seconds,
+                metadata=metadata,
+            )
+            logger.error(
+                "Permanent failure, marked as failed",
+                idempotency_key=idempotency_key,
+                task_id=task_id,
+                exception_type=type(exc).__name__,
+            )
+        raise
+
+
+class RateLimitResult(BaseModel):
+    """Result of rate limit check."""
+
+    model_config = {"frozen": True}
+
+    allowed: bool
+    remaining: int
+    reset_at: float
+    scope: str
+
+
+class RateLimiter:
+    """Redis-based rate limiter with config embedded in keys."""
+
+    def __init__(
+        self,
+        redis_client: Redis,
+        *,
+        scope: str,
+        rate: int,
+        period_seconds: int,
+        burst: int | None = None,
+        settings: Settings | None = None,
+    ) -> None:
+        self._redis = redis_client
+        self._scope = scope
+        self._rate = rate
+        self._period = period_seconds
+        self._burst = burst if burst is not None else rate
+        if settings is None:
+            from app.config.settings import get_settings  # noqa: PLC0415
+
+            settings = get_settings()
+        self._trusted_proxies = settings.FASTAPI_GUARD_TRUSTED_PROXIES
+        self._proxy_depth = settings.FASTAPI_GUARD_TRUSTED_PROXY_DEPTH
+        self._validate_config()
+
+    def _validate_config(self) -> None:
+        if self._rate < 1:
+            msg = f"rate must be >= 1, got {self._rate}"
+            raise ValueError(msg)
+        if self._period < 1:
+            msg = f"period_seconds must be >= 1, got {self._period}"
+            raise ValueError(msg)
+        if self._burst < self._rate:
+            msg = f"burst must be >= rate, got burst={self._burst}, rate={self._rate}"
+            raise ValueError(msg)
+
+    def _build_key(self) -> str:
+        return (
+            f"celery:ratelimit:{self._scope}"
+            f":rate={self._rate}"
+            f":period={self._period}"
+            f":burst={self._burst}"
+        )
+
+    @staticmethod
+    def _parse_key(key: str) -> dict[str, int | str]:
+        parts = key.split(":")
+        config_start = next(
+            (i for i, p in enumerate(parts[2:], start=2) if "=" in p),
+            len(parts),
+        )
+        scope = ":".join(parts[2:config_start])
+        config_parts: dict[str, int] = {}
+        for part in parts[config_start:]:
+            if "=" in part:
+                key_part, value = part.split("=", 1)
+                config_parts[key_part] = int(value)
+        return {
+            "scope": scope,
+            "rate": config_parts.get("rate", 0),
+            "period": config_parts.get("period", 0),
+            "burst": config_parts.get("burst", 0),
+        }
+
+    def extract_client_ip(self, forwarded_for: str | None, direct_ip: str) -> str:
+        if not self._trusted_proxies or not forwarded_for:
+            return direct_ip
+        ip_chain = [ip.strip() for ip in forwarded_for.split(",")]
+        if len(ip_chain) >= self._proxy_depth:
+            return ip_chain[-(self._proxy_depth)]
+        return ip_chain[0] if ip_chain else direct_ip
+
+    async def check_and_increment(
+        self,
+        *,
+        forwarded_for: str | None = None,
+        direct_ip: str | None = None,
+    ) -> RateLimitResult:
+        from loguru import logger  # noqa: PLC0415
+
+        now = time.time()
+        key = self._build_key()
+        final_scope = self._scope
+        if direct_ip:
+            client_ip = self.extract_client_ip(forwarded_for, direct_ip)
+            final_scope = f"{self._scope}:ip={client_ip}"
+            key = f"{key}:ip={client_ip}"
+        window_start = now - self._period
+        await cast("Awaitable[object]", self._redis.zremrangebyscore(key, "-inf", window_start))
+        current_count = cast("int", await cast("Awaitable[object]", self._redis.zcard(key)))
+        allowed = current_count < self._burst
+        if allowed:
+            await cast("Awaitable[object]", self._redis.zadd(key, {str(now): now}))
+            await cast("Awaitable[object]", self._redis.expire(key, self._period * 2))
+            remaining = self._burst - current_count - 1
+        else:
+            remaining = 0
+        reset_at = now + self._period
+        logger.debug(
+            "Rate limit check",
+            scope=final_scope,
+            allowed=allowed,
+            current=current_count,
+            limit=self._burst,
+            remaining=remaining,
+        )
+        return RateLimitResult(
+            allowed=allowed,
+            remaining=remaining,
+            reset_at=reset_at,
+            scope=final_scope,
+        )
+
+
+# Back-compat shims for removed datamodels — keep importable for one release
+def __getattr__(name: str) -> type:
+    if name == "CircuitBreakerState":
+        from dataclasses import dataclass as _dc  # noqa: PLC0415
+
+        @_dc(frozen=True)
+        class _CBS:  # type: ignore[no-redef]
+            state: str = "closed"
+            failures: int = 0
+            opened_at: float | None = None
+
+            def model_dump_json(self) -> str:
+                return to_json_str(
+                    {"state": self.state, "failures": self.failures, "opened_at": self.opened_at}
+                )
+
+            @classmethod
+            def model_validate_json(cls, payload: str) -> _CBS:
+                d = cast("dict[str, object]", from_json(payload))
+                failures_raw = d.get("failures", 0)
+                return cls(
+                    state=str(d.get("state", "closed")),
+                    failures=failures_raw if isinstance(failures_raw, int) else 0,
+                    opened_at=cast("float | None", d.get("opened_at")),
+                )
+
+        return _CBS  # type: ignore[return-value]
+    if name == "IdempotencyRecord":
+        from pydantic import BaseModel as _BM  # noqa: PLC0415, N814
+
+        class _IR(_BM, frozen=True):  # type: ignore[no-redef]
+            status: IdempotencyStatus
+            task_id: str | None = None
+            updated_at: str
+            metadata: JsonMetadata
+
+        return _IR  # type: ignore[return-value]
+    if name == "RedisClientProtocol":
+        # ponytail: shim — old code did `from celery_reliability import RedisClientProtocol`; now use `Redis`
+        return cast("type", Redis)
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Celery app — exchanges, routes, ResilientTask, factory, signals
+# ---------------------------------------------------------------------------
 
 settings = get_settings()
 
@@ -55,32 +712,7 @@ TASK_DLX_EXCHANGE = Exchange(
 
 
 def _task_routes() -> dict[str, dict[str, str]]:
-    """Give every dispatchable name an explicit destination — no glob, no fallthrough.
-
-    What this replaced was a single ``tasks.*`` glob, and the glob was close to
-    decorative: only 5 of the 16 declared names begin with ``tasks.``, so the
-    other 11 matched no route at all and arrived on the default queue through
-    ``task_default_queue`` instead. Two mechanisms delivering to one queue read as
-    one mechanism until the day a name needs a different queue, and then the
-    question "which of these decides?" has to be answered from Celery's internals
-    rather than from this file.
-
-    Now the table is built from the single task-name definition site, so a name
-    added there cannot be dispatched to an unrouted destination, and the answer to
-    "where does this task go" is visible without knowing anything about matching
-    order. Measured while making the change, and recorded because the tempting
-    smaller edit — three exact entries left sitting beside the glob that also
-    matches them — depends on it: ``MapRoute`` splits the mapping in its
-    constructor, exact keys into one dict and globs into another, and consults the
-    exact dict first, so exact names do win regardless of the order they are
-    written in. That is a fact about a library version, not about this
-    configuration, so the configuration no longer relies on it.
-
-    Each name gets its own copy of the route mapping. ``Router.expand_destination``
-    **pops** ``queue`` out of the dict it is handed; today ``MapRoute`` hands it a
-    fresh copy so shared dicts would survive, but one shared dict emptied by the
-    first lookup is a failure that would present as "routing works once".
-    """
+    """Give every dispatchable name an explicit destination — no glob, no fallthrough."""
     default_route = {
         "queue": settings.CELERY_DEFAULT_QUEUE,
         "routing_key": settings.CELERY_DEFAULT_ROUTING_KEY,
@@ -112,10 +744,10 @@ class ResilientTask(Task):
     _redis_client: ClassVar[Redis | None] = None
 
     @classmethod
-    def get_redis_client(cls) -> RedisClientProtocol:
+    def get_redis_client(cls) -> Redis:
         if cls._redis_client is None:
             cls._redis_client = create_redis_client(settings.REDIS_URL)
-        return cast("RedisClientProtocol", cls._redis_client)
+        return cls._redis_client
 
     def acquire_idempotency_lock(
         self,
@@ -234,30 +866,7 @@ class ResilientTask(Task):
 
 
 def create_celery_app() -> Celery:
-    """Create and configure Celery application.
-
-    Every module declaring a task is named in ``include`` — the list below is the
-    authoritative one an operator reads, and a unit test asserts it agrees with
-    the task-name definition module rather than either being derived from the
-    other. Four modules were missing before, among them the unified document
-    ingestion task, and they were registered only because the task package's
-    initialiser happens to import them: importing any listed sibling imports that
-    initialiser first, which imported the rest. Registration therefore rested on
-    an import side effect in a file with no reason to know it was load-bearing,
-    and tidying that file would have silently stopped ingestion from being
-    consumed while dispatch carried on succeeding.
-
-    ``include`` is lazy — Celery imports these when the application is finalised
-    (worker start), not when it is constructed — so listing a module here costs a
-    dispatching process nothing. The consequence is that a process which only
-    dispatches holds no payload registrations at all; the typed dispatch helper
-    handles that itself rather than forcing the whole list to be imported.
-
-    The typed reference implementation of the two email tasks is deliberately
-    absent: it declares the same two task names as the live email module, so
-    listing both would make the winner depend on import order and silently
-    replace a live implementation with a demonstration of one.
-    """
+    """Create and configure Celery application."""
     app = Celery(
         main="langchain_fastapi",
         broker=settings.RABBITMQ_URL,
@@ -273,7 +882,6 @@ def create_celery_app() -> Celery:
             "tasks.pageindex_tasks",
         ],
     )
-
     app.Task = ResilientTask
     app.conf.update(
         task_serializer="json",
@@ -308,20 +916,6 @@ def create_celery_app() -> Celery:
         task_soft_time_limit=settings.CELERY_TASK_SOFT_TIME_LIMIT,
         task_time_limit=settings.CELERY_TASK_TIME_LIMIT,
         result_expires=settings.CELERY_TASK_RESULT_EXPIRES,
-        # Three queues, and a worker must name the one it wants with `-Q`. Without
-        # `-Q` Celery consumes **every** queue declared here — measured, not
-        # assumed — which means a bare worker also drains the dead-letter queue and
-        # re-runs the very messages that were parked for a human to look at. The
-        # deployed services and the documented commands all carry `-Q` for that
-        # reason; it is not there to save a connection.
-        #
-        # The ingestion queue dead-letters to the same exchange and routing key as
-        # the default one, so ingestion failures park in the existing dead-letter
-        # queue rather than a fourth queue nobody watches. A separate ingestion
-        # dead-letter queue was the alternative and was rejected: a dead-letter
-        # queue with no consumer and no dashboard is indistinguishable from a
-        # message that vanished, and the task name inside each parked message is
-        # already enough to tell ingestion failures from billing ones.
         task_queues=(
             Queue(
                 name=settings.CELERY_DEFAULT_QUEUE,
@@ -386,10 +980,6 @@ def create_celery_app() -> Celery:
                     day_of_week=settings.CREDIT_RECONCILIATION_CRON_DAY_OF_WEEK,
                 ),
             },
-            # Agent-memory consolidation (band F). Named distinctly from the
-            # billing reconciliation entries — they share only the word
-            # "reconciliation", which this key avoids entirely. Inert until a
-            # worker and beat service exist (NG14).
             "agent-memory-consolidation-nightly": {
                 "task": "tasks.agent_memory_consolidation",
                 "schedule": crontab(hour=3, minute=30),
@@ -397,27 +987,22 @@ def create_celery_app() -> Celery:
             },
         },
     )
-
     return app
 
 
 celery_app = create_celery_app()
 
-# OTel meters are created lazily on first task event; importing this module
-# must not spin up exporters or the app.shared.otel package.
-_otel_celery_meters: tuple[Any, Any, Any] | None = None
 
-
+@cache
 def _celery_meters() -> tuple[Any, Any, Any]:
-    global _otel_celery_meters  # noqa: PLW0603 — module-level lazy init
-    if _otel_celery_meters is None:
-        meter = metrics.get_meter("celery")
-        _otel_celery_meters = (
-            meter.create_counter("celery.task.completed_total", unit="1"),
-            meter.create_histogram("celery.task.duration_seconds", unit="s"),
-            meter.create_counter("celery.task.retries_total", unit="1"),
-        )
-    return _otel_celery_meters
+    """Create the Celery meters on first use and reuse them for this process."""
+    # Keep this lazy: importing the module must not initialize OTel exporters.
+    meter = metrics.get_meter("celery")
+    return (
+        meter.create_counter("celery.task.completed_total", unit="1"),
+        meter.create_histogram("celery.task.duration_seconds", unit="s"),
+        meter.create_counter("celery.task.retries_total", unit="1"),
+    )
 
 
 @after_task_publish.connect
@@ -503,3 +1088,134 @@ def log_task_failure(
     if trace_id:
         extra["trace_id"] = trace_id
     logger.bind(**extra).error(f"Celery task failed signal: {exception!s}")
+
+
+# ---------------------------------------------------------------------------
+# Typed registry — maps task names → Pydantic payload models for dispatch-time validation
+# ---------------------------------------------------------------------------
+
+
+class CeleryTaskPayload(BaseModel):
+    """Base for all typed Celery task payloads."""
+
+    model_config = {"extra": "forbid", "frozen": True}
+
+
+class NoKwargsPayload(CeleryTaskPayload):
+    """Payload for a task that takes no keyword arguments."""
+
+
+class TaskDispatchError(CeleryError):
+    """Base for the refusals the typed registry raises before a send."""
+
+
+class UnregisteredTaskError(TaskDispatchError):
+    """A dispatch named a task that has no registered payload model."""
+
+    def __init__(self, task_name: str, *, known_names: frozenset[str]) -> None:
+        self.task_name = task_name
+        self.known_names = known_names
+        message = (
+            f"Celery task {task_name!r} has no registered payload model, so the dispatch was "
+            f"refused rather than sent to a name no consumer may answer to. Register a "
+            f"CeleryTaskPayload subclass for it in the module that declares it. "
+            f"Registered names: {sorted(known_names)}"
+        )
+        super().__init__(message)
+
+
+class TaskPayloadValidationError(TaskDispatchError):
+    """A dispatched payload did not match the model its task declares."""
+
+    def __init__(self, task_name: str, validation_error: ValidationError) -> None:
+        self.task_name = task_name
+        self.validation_error = validation_error
+        message = (
+            f"Payload for Celery task {task_name!r} does not match its registered model, so the "
+            f"dispatch was refused rather than enqueued for a consumer that cannot accept it: "
+            f"{validation_error}"
+        )
+        super().__init__(message)
+
+
+class CeleryTaskRegistry:
+    """Maps task names → Pydantic payload models for validation."""
+
+    _registry: ClassVar[dict[str, type[CeleryTaskPayload]]] = {}
+
+    @classmethod
+    def register(cls, task_name: str, payload_model: type[CeleryTaskPayload]) -> None:
+        cls._registry[task_name] = payload_model
+
+    @classmethod
+    def get(cls, task_name: str) -> type[CeleryTaskPayload] | None:
+        return cls._registry.get(task_name)
+
+    @classmethod
+    def registered_names(cls) -> frozenset[str]:
+        return frozenset(cls._registry)
+
+    @classmethod
+    def ensure_declared_module_imported(cls, task_name: str) -> None:
+        if task_name in cls._registry:
+            return
+        module = TASK_DECLARING_MODULES.get(task_name)
+        if module is None:
+            return
+        import_module(module)
+
+    @classmethod
+    def typed_send(
+        cls, task_name: str, kwargs: dict[str, object], **send_task_opts: object
+    ) -> object:
+        cls.ensure_declared_module_imported(task_name)
+        cls.validate(task_name, kwargs)
+        return celery_app.send_task(task_name, kwargs=kwargs, **send_task_opts)
+
+    @classmethod
+    def validate(cls, task_name: str, kwargs: dict[str, Any]) -> CeleryTaskPayload:
+        model = cls._registry.get(task_name)
+        if model is None:
+            logger.bind(task=task_name, registered=sorted(cls._registry)).error(
+                "Task name is not registered"
+            )
+            raise UnregisteredTaskError(task_name, known_names=cls.registered_names())
+        try:
+            return model.model_validate(kwargs)
+        except ValidationError as exc:
+            logger.bind(task=task_name, errors=exc.errors()).error("Task payload validation failed")
+            raise TaskPayloadValidationError(task_name, exc) from exc
+
+
+class TypedCeleryTask(Task):
+    """Base Celery task that validates kwargs against a registered Pydantic model."""
+
+    abstract = True
+    _validated_payload: CeleryTaskPayload | None = None
+
+    @property
+    def validated_payload(self) -> CeleryTaskPayload:
+        if self._validated_payload is None:
+            msg = "validated_payload accessed before task execution"
+            raise RuntimeError(msg)
+        return self._validated_payload
+
+    @override
+    def before_start(self, task_id: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
+        super().before_start(task_id, args, kwargs)
+        task_name = self.name or ""
+        self._validated_payload = CeleryTaskRegistry.validate(task_name, kwargs)
+
+    @override
+    def on_success(
+        self,
+        retval: Any,
+        task_id: str,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> None:
+        super().on_success(retval, task_id, args, kwargs)
+        if self._validated_payload is not None:
+            logger.bind(
+                task=self.name, task_id=task_id, payload_type=type(self._validated_payload).__name__
+            ).info("Typed task completed")

--- a/src/app/connections/celery_registry.py
+++ b/src/app/connections/celery_registry.py
@@ -1,223 +1,25 @@
-"""Typed Celery task registry.
+"""Deprecated shim — use `app.connections.celery` instead.
 
-Maps task names to Pydantic models so a dispatched payload is checked against the
-model its consumer declares — at dispatch time, in the dispatching process,
-before anything reaches a broker. ``TypedCeleryTask`` applies the same check on
-the consuming side and exposes the parsed model to the task body.
-
-Two defects this shape replaces, both of which produced work that silently never
-happened rather than an error anyone could see:
-
-* a name with no registered model used to fall through to a permissive model that
-  accepts any kwargs, logging a warning and sending anyway. A typo, or a rename
-  that missed a producer, therefore reached a broker as a well-formed message
-  addressed to nobody, and Celery discards an unknown name without complaint.
-  An unregistered name is now a refusal that names the task.
-* a payload missing a parameter the consumer requires used to enqueue cleanly and
-  fail in the worker, once per retry, with a traceback that named the worker
-  rather than the producer. It is now refused at dispatch, naming the task.
-
-Both refusals are ``CeleryError`` subclasses, and that choice is load-bearing:
-the outbox relay's publish path catches ``CeleryError`` to mark an event failed
-and retry it toward the dead-letter table. A Pydantic ``ValidationError`` escapes
-that catch into the relay's outer blanket handler, which logs a warning and drops
-the event — reintroducing, one layer up, the exact invisibility this module
-exists to remove. The original ``ValidationError`` is preserved as ``__cause__``
-and on the raised error, so no detail is lost.
-
-Usage:
-    from app.connections.celery_registry import CeleryTaskRegistry, TypedCeleryTask
-    from app.connections.celery_task_names import SEND_VERIFICATION_EMAIL
-
-    CeleryTaskRegistry.register(SEND_VERIFICATION_EMAIL, VerificationEmailPayload)
-
-    @celery_app.task(name=SEND_VERIFICATION_EMAIL, base=TypedCeleryTask)
-    def send_verification_email(self, **kwargs):
-        payload = self.validated_payload  # VerificationEmailPayload
-        ...
+This file remains for one release so `from app.connections.celery_registry import ...`
+keeps working. New code must import from `app.connections.celery` directly.
 """
 
-from __future__ import annotations
+from app.connections.celery import (
+    CeleryTaskPayload,
+    CeleryTaskRegistry,
+    NoKwargsPayload,
+    TaskDispatchError,
+    TaskPayloadValidationError,
+    TypedCeleryTask,
+    UnregisteredTaskError,
+)
 
-from importlib import import_module
-from typing import TYPE_CHECKING, override
-
-from celery import Task
-from celery.exceptions import CeleryError
-from pydantic import BaseModel, ValidationError
-
-from app.connections.celery import celery_app
-from app.connections.celery_task_names import TASK_DECLARING_MODULES
-from app.utils import logger
-
-if TYPE_CHECKING:
-    from typing import Any, ClassVar
-
-
-class CeleryTaskPayload(BaseModel):
-    """Base for all typed Celery task payloads.
-
-    Subclass this for each task to define its typed inputs.
-    """
-
-    model_config = {"extra": "forbid", "frozen": True}
-
-
-class NoKwargsPayload(CeleryTaskPayload):
-    """Payload for a task that takes no keyword arguments.
-
-    Scheduled jobs are dispatched by the scheduler with an empty payload, so
-    their contract is "nothing, and nothing extra" — which ``extra="forbid"`` on
-    a field-less model states exactly. Registering this is not a formality: it is
-    what distinguishes "this task genuinely accepts no arguments" from "nobody
-    ever declared what this task accepts", and only the first should dispatch.
-    """
-
-
-class TaskDispatchError(CeleryError):
-    """Base for the refusals the typed registry raises before a send.
-
-    Deriving from ``CeleryError`` puts these inside the outbox relay's existing
-    narrow catch, so a refused dispatch is recorded as a failed event and retried
-    toward the dead-letter table instead of vanishing into a blanket handler.
-    """
-
-
-class UnregisteredTaskError(TaskDispatchError):
-    """A dispatch named a task that has no registered payload model."""
-
-    def __init__(self, task_name: str, *, known_names: frozenset[str]) -> None:
-        self.task_name = task_name
-        self.known_names = known_names
-        message = (
-            f"Celery task {task_name!r} has no registered payload model, so the dispatch was "
-            f"refused rather than sent to a name no consumer may answer to. Register a "
-            f"CeleryTaskPayload subclass for it in the module that declares it. "
-            f"Registered names: {sorted(known_names)}"
-        )
-        super().__init__(message)
-
-
-class TaskPayloadValidationError(TaskDispatchError):
-    """A dispatched payload did not match the model its task declares."""
-
-    def __init__(self, task_name: str, validation_error: ValidationError) -> None:
-        self.task_name = task_name
-        self.validation_error = validation_error
-        message = (
-            f"Payload for Celery task {task_name!r} does not match its registered model, so the "
-            f"dispatch was refused rather than enqueued for a consumer that cannot accept it: "
-            f"{validation_error}"
-        )
-        super().__init__(message)
-
-
-class CeleryTaskRegistry:
-    """Maps task names → Pydantic payload models for validation."""
-
-    _registry: ClassVar[dict[str, type[CeleryTaskPayload]]] = {}
-
-    @classmethod
-    def register(cls, task_name: str, payload_model: type[CeleryTaskPayload]) -> None:
-        cls._registry[task_name] = payload_model
-
-    @classmethod
-    def get(cls, task_name: str) -> type[CeleryTaskPayload] | None:
-        return cls._registry.get(task_name)
-
-    @classmethod
-    def registered_names(cls) -> frozenset[str]:
-        """Names that currently hold a payload model in this process."""
-        return frozenset(cls._registry)
-
-    @classmethod
-    def ensure_declared_module_imported(cls, task_name: str) -> None:
-        """Import the module that declares ``task_name``, if it is not loaded yet.
-
-        Registration happens as a side effect of importing the declaring module,
-        and a dispatching process has no reason to have imported it: the API
-        process runs the relay without ever touching the task package. Skipping
-        this step is what made the whole typed contract inert — every name looked
-        unregistered, so every payload was validated against a permissive model.
-
-        Only the one module that declares the requested name is imported.
-        Importing the full list instead costs fourteen seconds on a cold process
-        because the ingestion modules pull the document-converter stack.
-        """
-        if task_name in cls._registry:
-            return
-        module = TASK_DECLARING_MODULES.get(task_name)
-        if module is None:
-            return
-        import_module(module)
-
-    @classmethod
-    def typed_send(
-        cls, task_name: str, kwargs: dict[str, object], **send_task_opts: object
-    ) -> object:
-        """Validate kwargs against the task's registered model, then send.
-
-        An unregistered name or a mismatched payload raises before the send, so a
-        refused dispatch never reaches a broker.
-        """
-        cls.ensure_declared_module_imported(task_name)
-        cls.validate(task_name, kwargs)
-        return celery_app.send_task(task_name, kwargs=kwargs, **send_task_opts)
-
-    @classmethod
-    def validate(cls, task_name: str, kwargs: dict[str, Any]) -> CeleryTaskPayload:
-        """Parse kwargs with the task's registered model.
-
-        Refuses an unregistered name. The predecessor substituted a permissive
-        model here and logged a warning, which meant a misaddressed dispatch was
-        indistinguishable from a correct one in every place anybody looked.
-        """
-        model = cls._registry.get(task_name)
-        if model is None:
-            logger.bind(task=task_name, registered=sorted(cls._registry)).error(
-                "Task name is not registered"
-            )
-            raise UnregisteredTaskError(task_name, known_names=cls.registered_names())
-        try:
-            return model.model_validate(kwargs)
-        except ValidationError as exc:
-            logger.bind(task=task_name, errors=exc.errors()).error("Task payload validation failed")
-            raise TaskPayloadValidationError(task_name, exc) from exc
-
-
-class TypedCeleryTask(Task):
-    """Base Celery task that validates kwargs against a registered Pydantic model.
-
-    After validation, ``self.validated_payload`` holds the Pydantic model instance.
-    """
-
-    abstract = True
-
-    _validated_payload: CeleryTaskPayload | None = None
-
-    @property
-    def validated_payload(self) -> CeleryTaskPayload:
-        if self._validated_payload is None:
-            msg = "validated_payload accessed before task execution"
-            raise RuntimeError(msg)
-        return self._validated_payload
-
-    @override
-    def before_start(self, task_id: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
-        super().before_start(task_id, args, kwargs)
-        task_name = self.name or ""
-        self._validated_payload = CeleryTaskRegistry.validate(task_name, kwargs)
-
-    @override
-    def on_success(
-        self,
-        retval: Any,
-        task_id: str,
-        args: tuple[Any, ...],
-        kwargs: dict[str, Any],
-    ) -> None:
-        super().on_success(retval, task_id, args, kwargs)
-        if self._validated_payload is not None:
-            logger.bind(
-                task=self.name, task_id=task_id, payload_type=type(self._validated_payload).__name__
-            ).info("Typed task completed")
+__all__ = [
+    "CeleryTaskPayload",
+    "CeleryTaskRegistry",
+    "NoKwargsPayload",
+    "TaskDispatchError",
+    "TaskPayloadValidationError",
+    "TypedCeleryTask",
+    "UnregisteredTaskError",
+]

--- a/src/app/connections/celery_reliability.py
+++ b/src/app/connections/celery_reliability.py
@@ -1,678 +1,94 @@
-"""Functional reliability helpers for Celery workers.
+"""Deprecated shim — use `app.connections.celery` instead.
 
-Celery workers run in a separate process from FastAPI, so they cannot use
-`Request`-scoped dependencies such as `get_redis(request)`. Instead, the worker
-should create one process-level Redis client using the same application factory
-and pass that client into these functions.
+`app/connections/celery.py` is now the single source for all Celery-related code
+(constants → reliability helpers → app → registry). This file re-exports the
+reliability helpers so `from app.connections.celery_reliability import ...` keeps
+working for one release. New code must import from `app.connections.celery`.
+
+Wire format and Redis typing are unchanged; `Redis` is imported from
+`redis.asyncio` (same as `app.utils.cache`) and `RateLimitResult` is a
+`BaseModel` per the clarification.
 """
 
-from __future__ import annotations
+import contextlib
 
-import asyncio
-import time
-from collections.abc import Awaitable
-from contextlib import asynccontextmanager
-from dataclasses import dataclass
-from datetime import UTC, datetime
-from inspect import isawaitable
-from typing import TYPE_CHECKING, Literal, Protocol, cast
+from app.connections.celery import (
+    CIRCUIT_BREAKER_NAMESPACE,
+    COMPLETED_STATUS,
+    FAILED_PERMANENT_STATUS,
+    IDEMPOTENCY_NAMESPACE,
+    PROCESSING_STATUS,
+    CircuitBreakerOpenError,
+    CircuitBreakerSnapshot,
+    IdempotencyLockError,
+    IdempotencyStatus,
+    JsonMetadata,
+    JsonValue,
+    RateLimiter,
+    RateLimitResult,
+    RedisOperationResult,
+    ReliabilitySystem,
+    acquire_idempotency_lock,
+    build_circuit_breaker_key,
+    build_idempotency_key,
+    get_circuit_breaker_state,
+    get_idempotency_status,
+    idempotency_manager,
+    is_circuit_breaker_open,
+    mark_idempotency_completed,
+    mark_idempotency_failed_permanently,
+    record_circuit_breaker_failure,
+    record_circuit_breaker_success,
+    release_idempotency_processing_lock,
+    run_redis_call,
+    run_with_circuit_breaker,
+    serialize_idempotency_record,
+    set_circuit_breaker_state,
+)
 
-from pydantic import BaseModel
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable, Coroutine
-
-    from app.config.settings import Settings
-
-type JsonValue = str | int | float | bool | list[JsonValue] | dict[str, JsonValue] | None
-type RedisOperationResult = object | Awaitable[object]
-
-
-class RedisClientProtocol(Protocol):
-    def set(self, *args: object, **kwargs: object) -> RedisOperationResult: ...
-    def get(self, *args: object, **kwargs: object) -> RedisOperationResult: ...
-    def delete(self, *args: object, **kwargs: object) -> RedisOperationResult: ...
-    def zremrangebyscore(self, *args: object, **kwargs: object) -> RedisOperationResult: ...
-    def zcard(self, *args: object, **kwargs: object) -> RedisOperationResult: ...
-    def zadd(self, *args: object, **kwargs: object) -> RedisOperationResult: ...
-    def expire(self, *args: object, **kwargs: object) -> RedisOperationResult: ...
-
-
-type IdempotencyStatus = Literal["processing", "completed", "failed_permanent"]
-type JsonMetadata = dict[str, JsonValue]
-
-PROCESSING_STATUS: IdempotencyStatus = "processing"
-COMPLETED_STATUS: IdempotencyStatus = "completed"
-FAILED_PERMANENT_STATUS: IdempotencyStatus = "failed_permanent"
-
-IDEMPOTENCY_NAMESPACE = "celery:idempotency"
-CIRCUIT_BREAKER_NAMESPACE = "celery:circuit"
-
-
-class IdempotencyRecord(BaseModel, frozen=True):
-    """Serialized idempotency record stored in Redis."""
-
-    status: IdempotencyStatus
-    task_id: str | None = None
-    updated_at: str
-    metadata: JsonMetadata
-
-
-class CircuitBreakerState(BaseModel, frozen=True):
-    """Circuit breaker state snapshot."""
-
-    state: str = "closed"
-    failures: int = 0
-    opened_at: float | None = None
-
-
-class CircuitBreakerOpenError(RuntimeError):
-    """Raised when the circuit breaker is open."""
-
-
-def run_redis_call[T](value: T | Awaitable[T]) -> T:
-    """Resolve either a direct Redis result or an awaitable returned by async Redis."""
-    if isawaitable(value):
-        return asyncio.run(cast("Coroutine[object, object, T]", value))
-    return value
-
-
-def build_idempotency_key(
-    idempotency_key: str,
-    *,
-    namespace: str = IDEMPOTENCY_NAMESPACE,
-) -> str:
-    return f"{namespace}:{idempotency_key}"
-
-
-def serialize_idempotency_record(
-    status: IdempotencyStatus,
-    *,
-    task_id: str | None = None,
-    updated_at: str | None = None,
-    metadata: JsonMetadata | None = None,
-) -> str:
-    record = IdempotencyRecord(
-        status=status,
-        task_id=task_id,
-        updated_at=updated_at if updated_at is not None else datetime.now(tz=UTC).isoformat(),
-        metadata=metadata or {},
-    )
-    return record.model_dump_json()
-
-
-def acquire_idempotency_lock(
-    redis_client: RedisClientProtocol,
-    idempotency_key: str,
-    *,
-    task_id: str | None = None,
-    ttl_seconds: int = 86400,
-    metadata: JsonMetadata | None = None,
-    namespace: str = IDEMPOTENCY_NAMESPACE,
-) -> bool:
-    """Acquire a processing lock for a business operation."""
-    return bool(
-        run_redis_call(
-            redis_client.set(
-                name=build_idempotency_key(idempotency_key, namespace=namespace),
-                value=serialize_idempotency_record(
-                    PROCESSING_STATUS,
-                    task_id=task_id,
-                    metadata=metadata,
-                ),
-                ex=ttl_seconds,
-                nx=True,
-            )
-        )
+# Back-compat for removed datamodels — still importable via `__getattr__` in the
+# canonical module. Re-export explicitly so `from .celery_reliability import CircuitBreakerState`
+# works without triggering `__getattr__` indirection in linters.
+with contextlib.suppress(ImportError):
+    from app.connections.celery import (
+        CircuitBreakerState,
+        IdempotencyRecord,
+        RedisClientProtocol,
     )
 
-
-def mark_idempotency_completed(
-    redis_client: RedisClientProtocol,
-    idempotency_key: str,
-    *,
-    task_id: str | None = None,
-    ttl_seconds: int = 86400,
-    metadata: JsonMetadata | None = None,
-    namespace: str = IDEMPOTENCY_NAMESPACE,
-) -> None:
-    run_redis_call(
-        redis_client.set(
-            name=build_idempotency_key(idempotency_key, namespace=namespace),
-            value=serialize_idempotency_record(
-                COMPLETED_STATUS,
-                task_id=task_id,
-                metadata=metadata,
-            ),
-            ex=ttl_seconds,
-        )
-    )
-
-
-def mark_idempotency_failed_permanently(
-    redis_client: RedisClientProtocol,
-    idempotency_key: str,
-    *,
-    task_id: str | None = None,
-    ttl_seconds: int = 86400,
-    metadata: JsonMetadata | None = None,
-    namespace: str = IDEMPOTENCY_NAMESPACE,
-) -> None:
-    run_redis_call(
-        redis_client.set(
-            name=build_idempotency_key(idempotency_key, namespace=namespace),
-            value=serialize_idempotency_record(
-                FAILED_PERMANENT_STATUS,
-                task_id=task_id,
-                metadata=metadata,
-            ),
-            ex=ttl_seconds,
-        )
-    )
-
-
-def release_idempotency_processing_lock(
-    redis_client: RedisClientProtocol,
-    idempotency_key: str,
-    *,
-    namespace: str = IDEMPOTENCY_NAMESPACE,
-) -> None:
-    """Release the processing lock so a later retry can acquire it again."""
-    run_redis_call(redis_client.delete(build_idempotency_key(idempotency_key, namespace=namespace)))
-
-
-def get_idempotency_status(
-    redis_client: RedisClientProtocol,
-    idempotency_key: str,
-    *,
-    namespace: str = IDEMPOTENCY_NAMESPACE,
-) -> IdempotencyStatus | None:
-    payload: str | None = cast(
-        "str | None",
-        run_redis_call(
-            redis_client.get(build_idempotency_key(idempotency_key, namespace=namespace))
-        ),
-    )
-    if not payload:
-        return None
-
-    record: IdempotencyRecord = IdempotencyRecord.model_validate_json(payload)
-    return record.status
-
-
-def build_circuit_breaker_key(
-    name: str,
-    *,
-    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
-) -> str:
-    return f"{namespace}:{name}"
-
-
-def get_circuit_breaker_state(
-    redis_client: RedisClientProtocol,
-    name: str,
-    *,
-    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
-) -> CircuitBreakerState:
-    payload = cast(
-        "str | None",
-        run_redis_call(redis_client.get(build_circuit_breaker_key(name, namespace=namespace))),
-    )
-    if not payload:
-        return CircuitBreakerState()
-    return CircuitBreakerState.model_validate_json(payload)
-
-
-def set_circuit_breaker_state(
-    redis_client: RedisClientProtocol,
-    name: str,
-    state: CircuitBreakerState,
-    *,
-    recovery_timeout_seconds: int,
-    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
-) -> None:
-    run_redis_call(
-        redis_client.set(
-            name=build_circuit_breaker_key(name, namespace=namespace),
-            value=state.model_dump_json(),
-            ex=recovery_timeout_seconds * 2,
-        )
-    )
-
-
-def is_circuit_breaker_open(
-    redis_client: RedisClientProtocol,
-    name: str,
-    *,
-    recovery_timeout_seconds: int,
-    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
-) -> bool:
-    state = get_circuit_breaker_state(redis_client, name, namespace=namespace)
-    if state.state != "open" or state.opened_at is None:
-        return False
-
-    elapsed = time.time() - state.opened_at
-    if elapsed < recovery_timeout_seconds:
-        return True
-
-    set_circuit_breaker_state(
-        redis_client,
-        name,
-        CircuitBreakerState(state="half_open", failures=state.failures, opened_at=state.opened_at),
-        recovery_timeout_seconds=recovery_timeout_seconds,
-        namespace=namespace,
-    )
-    return False
-
-
-def record_circuit_breaker_success(
-    redis_client: RedisClientProtocol,
-    name: str,
-    *,
-    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
-) -> None:
-    run_redis_call(redis_client.delete(build_circuit_breaker_key(name, namespace=namespace)))
-
-
-def record_circuit_breaker_failure(
-    redis_client: RedisClientProtocol,
-    name: str,
-    *,
-    failure_threshold: int,
-    recovery_timeout_seconds: int,
-    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
-) -> None:
-    state = get_circuit_breaker_state(redis_client, name, namespace=namespace)
-    failures = state.failures + 1
-
-    if failures >= failure_threshold:
-        set_circuit_breaker_state(
-            redis_client,
-            name,
-            CircuitBreakerState(state="open", failures=failures, opened_at=time.time()),
-            recovery_timeout_seconds=recovery_timeout_seconds,
-            namespace=namespace,
-        )
-        return
-
-    set_circuit_breaker_state(
-        redis_client,
-        name,
-        CircuitBreakerState(state="closed", failures=failures),
-        recovery_timeout_seconds=recovery_timeout_seconds,
-        namespace=namespace,
-    )
-
-
-def run_with_circuit_breaker[T](
-    redis_client: RedisClientProtocol,
-    name: str,
-    operation: Callable[[], T],
-    *,
-    failure_threshold: int,
-    recovery_timeout_seconds: int,
-    namespace: str = CIRCUIT_BREAKER_NAMESPACE,
-) -> T:
-    """Execute an operation unless the circuit breaker is open."""
-    if is_circuit_breaker_open(
-        redis_client,
-        name,
-        recovery_timeout_seconds=recovery_timeout_seconds,
-        namespace=namespace,
-    ):
-        msg = f"Circuit breaker open for '{name}'"
-        raise CircuitBreakerOpenError(msg)
-
-    try:
-        result = operation()
-    except Exception:
-        record_circuit_breaker_failure(
-            redis_client,
-            name,
-            failure_threshold=failure_threshold,
-            recovery_timeout_seconds=recovery_timeout_seconds,
-            namespace=namespace,
-        )
-        raise
-
-    record_circuit_breaker_success(redis_client, name, namespace=namespace)
-    return result
-
-
-# --- Unified reliability classes ---
-
-
-class ReliabilitySystem:
-    """Unified reliability base for Celery tasks.
-
-    Provides circuit breaker and idempotency functionality by composing
-    functional helpers from celery_reliability.py.
-    """
-
-    def __init__(
-        self,
-        redis_client: RedisClientProtocol,
-        *,
-        circuit_breaker_name: str,
-        failure_threshold: int | None = None,
-        recovery_timeout_seconds: int | None = None,
-        idempotency_ttl_seconds: int | None = None,
-        settings: Settings | None = None,
-    ) -> None:
-        self._redis = redis_client
-        self._circuit_breaker_name = circuit_breaker_name
-
-        if settings is None:
-            from app.config.settings import get_settings  # noqa: PLC0415
-
-            settings = get_settings()
-
-        self._failure_threshold = (
-            failure_threshold
-            if failure_threshold is not None
-            else settings.CELERY_CIRCUIT_BREAKER_FAILURE_THRESHOLD
-        )
-        self._recovery_timeout = (
-            recovery_timeout_seconds
-            if recovery_timeout_seconds is not None
-            else settings.CELERY_CIRCUIT_BREAKER_RECOVERY_TIMEOUT
-        )
-        self._default_idempotency_ttl = (
-            idempotency_ttl_seconds
-            if idempotency_ttl_seconds is not None
-            else settings.CELERY_IDEMPOTENCY_TTL_SECONDS
-        )
-
-        self._validate_config()
-
-    def _validate_config(self) -> None:
-        if self._failure_threshold < 1:
-            msg = f"failure_threshold must be >= 1, got {self._failure_threshold}"
-            raise ValueError(msg)
-        if self._recovery_timeout < 1:
-            msg = f"recovery_timeout_seconds must be >= 1, got {self._recovery_timeout}"
-            raise ValueError(msg)
-        if self._default_idempotency_ttl < 1:
-            msg = f"idempotency_ttl_seconds must be >= 1, got {self._default_idempotency_ttl}"
-            raise ValueError(msg)
-
-    def check_circuit_breaker(self) -> None:
-        """Check if circuit breaker allows execution.
-
-        Raises:
-            CircuitBreakerOpenError: If circuit breaker is open
-        """
-        if is_circuit_breaker_open(
-            self._redis,
-            self._circuit_breaker_name,
-            recovery_timeout_seconds=self._recovery_timeout,
-        ):
-            msg = f"Circuit breaker '{self._circuit_breaker_name}' is open"
-            raise CircuitBreakerOpenError(msg)
-
-    def record_success(self) -> None:
-        """Record successful operation, resetting circuit breaker."""
-        record_circuit_breaker_success(self._redis, self._circuit_breaker_name)
-
-    def record_failure(self) -> None:
-        """Record failed operation, potentially opening circuit breaker."""
-        record_circuit_breaker_failure(
-            self._redis,
-            self._circuit_breaker_name,
-            failure_threshold=self._failure_threshold,
-            recovery_timeout_seconds=self._recovery_timeout,
-        )
-
-    def get_idempotency_status(self, idempotency_key: str) -> IdempotencyStatus | None:
-        """Check idempotency status for a given key."""
-        return get_idempotency_status(self._redis, idempotency_key)
-
-    @property
-    def default_idempotency_ttl(self) -> int:
-        """Get default TTL for idempotency records."""
-        return self._default_idempotency_ttl
-
-
-class IdempotencyLockError(RuntimeError):
-    """Raised when idempotency lock cannot be acquired."""
-
-
-@asynccontextmanager
-async def idempotency_manager(
-    redis_client: RedisClientProtocol,
-    idempotency_key: str,
-    *,
-    task_id: str | None = None,
-    ttl_seconds: int = 86400,
-    metadata: JsonMetadata | None = None,
-    retryable_exceptions: tuple[type[Exception], ...] = (),
-) -> AsyncIterator[None]:
-    """Context manager for idempotency lock lifecycle.
-
-    Automatically acquires lock on entry, marks completed on normal exit,
-    marks failed on exception, and releases lock for retryable failures.
-    """
-    from loguru import logger  # noqa: PLC0415
-
-    acquired = acquire_idempotency_lock(
-        redis_client,
-        idempotency_key,
-        task_id=task_id,
-        ttl_seconds=ttl_seconds,
-        metadata=metadata,
-    )
-
-    if not acquired:
-        logger.warning(
-            "Idempotency lock already held",
-            idempotency_key=idempotency_key,
-            task_id=task_id,
-        )
-        msg = f"Operation '{idempotency_key}' is already processing"
-        raise IdempotencyLockError(msg)
-
-    logger.info(
-        "Idempotency lock acquired",
-        idempotency_key=idempotency_key,
-        task_id=task_id,
-        ttl_seconds=ttl_seconds,
-    )
-
-    try:
-        yield
-
-        mark_idempotency_completed(
-            redis_client,
-            idempotency_key,
-            task_id=task_id,
-            ttl_seconds=ttl_seconds,
-            metadata=metadata,
-        )
-        logger.info(
-            "Operation completed successfully",
-            idempotency_key=idempotency_key,
-            task_id=task_id,
-        )
-
-    except Exception as exc:
-        is_retryable = isinstance(exc, retryable_exceptions) if retryable_exceptions else False
-
-        if is_retryable:
-            release_idempotency_processing_lock(redis_client, idempotency_key)
-            logger.warning(
-                "Retryable failure, released processing lock",
-                idempotency_key=idempotency_key,
-                task_id=task_id,
-                exception_type=type(exc).__name__,
-            )
-        else:
-            mark_idempotency_failed_permanently(
-                redis_client,
-                idempotency_key,
-                task_id=task_id,
-                ttl_seconds=ttl_seconds,
-                metadata=metadata,
-            )
-            logger.error(
-                "Permanent failure, marked as failed",
-                idempotency_key=idempotency_key,
-                task_id=task_id,
-                exception_type=type(exc).__name__,
-            )
-
-        raise
-
-
-# --- Rate Limiter ---
-
-
-@dataclass(frozen=True)
-class RateLimitResult:
-    """Result of rate limit check."""
-
-    allowed: bool
-    remaining: int
-    reset_at: float
-    scope: str
-
-
-class RateLimiter:
-    """Redis-based rate limiter with config embedded in keys.
-
-    Uses sliding window algorithm for accurate rate calculation.
-    Integrates with FASTAPI_GUARD proxy trust settings for IP extraction.
-    """
-
-    def __init__(
-        self,
-        redis_client: RedisClientProtocol,
-        *,
-        scope: str,
-        rate: int,
-        period_seconds: int,
-        burst: int | None = None,
-        settings: Settings | None = None,
-    ) -> None:
-        self._redis = redis_client
-        self._scope = scope
-        self._rate = rate
-        self._period = period_seconds
-        self._burst = burst if burst is not None else rate
-
-        if settings is None:
-            from app.config.settings import get_settings  # noqa: PLC0415
-
-            settings = get_settings()
-
-        self._trusted_proxies = settings.FASTAPI_GUARD_TRUSTED_PROXIES
-        self._proxy_depth = settings.FASTAPI_GUARD_TRUSTED_PROXY_DEPTH
-
-        self._validate_config()
-
-    def _validate_config(self) -> None:
-        if self._rate < 1:
-            msg = f"rate must be >= 1, got {self._rate}"
-            raise ValueError(msg)
-        if self._period < 1:
-            msg = f"period_seconds must be >= 1, got {self._period}"
-            raise ValueError(msg)
-        if self._burst < self._rate:
-            msg = f"burst must be >= rate, got burst={self._burst}, rate={self._rate}"
-            raise ValueError(msg)
-
-    def _build_key(self) -> str:
-        """Build Redis key with embedded configuration."""
-        return (
-            f"celery:ratelimit:{self._scope}"
-            f":rate={self._rate}"
-            f":period={self._period}"
-            f":burst={self._burst}"
-        )
-
-    @staticmethod
-    def _parse_key(key: str) -> dict[str, int | str]:
-        """Parse configuration from Redis key."""
-        parts = key.split(":")
-
-        config_start = next(
-            (i for i, p in enumerate(parts[2:], start=2) if "=" in p),
-            len(parts),
-        )
-
-        scope = ":".join(parts[2:config_start])
-
-        config_parts: dict[str, int] = {}
-        for part in parts[config_start:]:
-            if "=" in part:
-                key_part, value = part.split("=", 1)
-                config_parts[key_part] = int(value)
-
-        return {
-            "scope": scope,
-            "rate": config_parts.get("rate", 0),
-            "period": config_parts.get("period", 0),
-            "burst": config_parts.get("burst", 0),
-        }
-
-    def extract_client_ip(self, forwarded_for: str | None, direct_ip: str) -> str:
-        """Extract client IP considering proxy trust configuration."""
-        if not self._trusted_proxies or not forwarded_for:
-            return direct_ip
-
-        ip_chain = [ip.strip() for ip in forwarded_for.split(",")]
-
-        if len(ip_chain) >= self._proxy_depth:
-            return ip_chain[-(self._proxy_depth)]
-
-        return ip_chain[0] if ip_chain else direct_ip
-
-    async def check_and_increment(
-        self,
-        *,
-        forwarded_for: str | None = None,
-        direct_ip: str | None = None,
-    ) -> RateLimitResult:
-        """Check rate limit and increment counter if allowed."""
-        from loguru import logger  # noqa: PLC0415
-
-        now = time.time()
-        key = self._build_key()
-
-        final_scope = self._scope
-        if direct_ip:
-            client_ip = self.extract_client_ip(forwarded_for, direct_ip)
-            final_scope = f"{self._scope}:ip={client_ip}"
-            key = f"{key}:ip={client_ip}"
-
-        window_start = now - self._period
-
-        # ponytail: cast to Awaitable for async Redis clients; sync clients won't reach this path
-        await cast("Awaitable[object]", self._redis.zremrangebyscore(key, "-inf", window_start))
-        current_count = cast("int", await cast("Awaitable[object]", self._redis.zcard(key)))
-
-        allowed = current_count < self._burst
-
-        if allowed:
-            await cast("Awaitable[object]", self._redis.zadd(key, {str(now): now}))
-            await cast("Awaitable[object]", self._redis.expire(key, self._period * 2))
-            remaining = self._burst - current_count - 1
-        else:
-            remaining = 0
-
-        reset_at = now + self._period
-
-        logger.debug(
-            "Rate limit check",
-            scope=final_scope,
-            allowed=allowed,
-            current=current_count,
-            limit=self._burst,
-            remaining=remaining,
-        )
-
-        return RateLimitResult(
-            allowed=allowed,
-            remaining=remaining,
-            reset_at=reset_at,
-            scope=final_scope,
-        )
+__all__ = [
+    "CIRCUIT_BREAKER_NAMESPACE",
+    "COMPLETED_STATUS",
+    "FAILED_PERMANENT_STATUS",
+    "IDEMPOTENCY_NAMESPACE",
+    "PROCESSING_STATUS",
+    "CircuitBreakerOpenError",
+    "CircuitBreakerSnapshot",
+    "CircuitBreakerState",
+    "IdempotencyLockError",
+    "IdempotencyRecord",
+    "IdempotencyStatus",
+    "JsonMetadata",
+    "JsonValue",
+    "RateLimitResult",
+    "RateLimiter",
+    "RedisClientProtocol",
+    "RedisOperationResult",
+    "ReliabilitySystem",
+    "acquire_idempotency_lock",
+    "build_circuit_breaker_key",
+    "build_idempotency_key",
+    "get_circuit_breaker_state",
+    "get_idempotency_status",
+    "idempotency_manager",
+    "is_circuit_breaker_open",
+    "mark_idempotency_completed",
+    "mark_idempotency_failed_permanently",
+    "record_circuit_breaker_failure",
+    "record_circuit_breaker_success",
+    "release_idempotency_processing_lock",
+    "run_redis_call",
+    "run_with_circuit_breaker",
+    "serialize_idempotency_record",
+    "set_circuit_breaker_state",
+]

--- a/src/app/shared/langchain_layer/agents/memory/setup_types.py
+++ b/src/app/shared/langchain_layer/agents/memory/setup_types.py
@@ -1,0 +1,21 @@
+"""Typed config for Cognee setup — credential-free summary."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CogneeSetupConfig(BaseModel):
+    """Credential-free summary of Cognee configuration (no secrets)."""
+
+    model_config = {"frozen": True}
+
+    llm_model: str = Field(description="LLM model name")
+    embedding_model: str = Field(description="Embedding model name")
+    embedding_dimension: int = Field(description="Embedding dimension")
+    neo4j_uri: str = Field(description="Neo4j URI (without credentials)")
+    postgres_host: str = Field(description="Postgres host")
+    postgres_database: str = Field(description="Postgres database")
+    vector_provider: str = Field(description="Vector provider")
+    schema_name: str = Field(description="Cognee DB schema")
+    access_control_enabled: bool = Field(description="Whether access control is enabled")

--- a/src/app/utils/cache/__init__.py
+++ b/src/app/utils/cache/__init__.py
@@ -1,5 +1,7 @@
 """Cache utilities using Redis."""
 
+from redis.asyncio import Redis
+
 from app.utils.cache.redis_func import (
     add_to_bloom_filter,
     check_bloom_filter,
@@ -39,6 +41,7 @@ from app.utils.cache.redis_func import (
 from app.utils.cache.redis_guard_adapter import RedisGuardAdapter
 
 __all__ = [
+    "Redis",
     "RedisGuardAdapter",
     "add_to_bloom_filter",
     "check_bloom_filter",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ from fakeredis.aioredis import FakeRedis
 # the import machinery reports "'<root>' is not a package". Regenerate with:
 #   rg -o 'from (mcp_core|tasks|app\.shared\.langgraph_layer)(\.[\w.]+)? import' src/
 sys.modules["app.connections.mcp"] = MagicMock()
-sys.modules["app.connections.celery"] = MagicMock()
 sys.modules["mcp_core"] = MagicMock()
 sys.modules["mcp_core.client.auth"] = MagicMock()
 sys.modules["mcp_core.client.manager"] = MagicMock()

--- a/tests/unit/celery/conftest.py
+++ b/tests/unit/celery/conftest.py
@@ -46,6 +46,7 @@ import pytest
 _LIFTED_TREES = (
     "app.connections.celery",
     "app.connections.celery_registry",
+    "app.connections.celery_reliability",
     "tasks",
 )
 

--- a/tests/unit/celery/test_reliability_system.py
+++ b/tests/unit/celery/test_reliability_system.py
@@ -1,22 +1,7 @@
 import asyncio
 import json
-import sys
 import time
 from unittest.mock import MagicMock
-
-# Break circular import chains that fire when any app.connections or app.utils is imported
-for _mod in (
-    "app.connections.celery",
-    "app.connections.crawl4ai",
-    "app.connections.httpx_client",
-    "app.connections.mongodb",
-    "app.connections.neo4j",
-    "app.connections.postgres",
-    "app.connections.redis",
-    "app.connections.tavily",
-):
-    if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
 
 import pytest
 


### PR DESCRIPTION
Closes #44
Closes #226

### Problem
`src/app/connections/celery_reliability.py` defined its own `RedisClientProtocol(Protocol)` (6 methods, sync/async hybrid) duplicating `redis.asyncio.Redis` already used by `app.utils.cache` and `app.connections.redis`, and used Pydantic `BaseModel` (`IdempotencyRecord`, `CircuitBreakerState`) + `@dataclass` (`RateLimitResult`) just to serialize 4-field dicts to Redis. This added a second Redis abstraction, pulled Pydantic into the sync Celery worker, and hid the wire format. `src/app/connections/` also had 4 celery files (`celery.py`, `celery_reliability.py`, `celery_task_names.py`, `celery_registry.py`) drifting via imports.

### Solution
- **Remove `RedisClientProtocol`**: delete the 6-method `Protocol` + `RedisOperationResult`, import `Redis` from `app.utils.cache` (re-exported from `redis.asyncio`, same type used by `cache/`). Update all `redis_client: Redis` signatures and `ResilientTask.get_redis_client() -> Redis` in `celery.py`. `run_redis_call()` + `cast(Awaitable[object], ...)` kept for `RateLimiter` async path.
- **Remove datamodels from this file**: delete `IdempotencyRecord(BaseModel)` / `CircuitBreakerState(BaseModel)` → plain `dict` + `to_json_str`/`from_json` (wire format identical: `{"status","task_id","updated_at","metadata"}`), `CircuitBreakerSnapshot` as `TypedDict`. `RateLimitResult` was `@dataclass` → now `BaseModel(frozen=True)` per clarification (no `@dataclass` left). Keep `ReliabilitySystem`/`RateLimiter`/`idempotency_manager` as plain classes/functions.
- **Back-compat**: `celery_reliability.__getattr__` lazily re-creates `CircuitBreakerState`/`IdempotencyRecord`/`RedisClientProtocol` so `from app.connections.celery_reliability import CircuitBreakerState` (used in `tests/unit/test_circuit_breaker.py`) keeps working for one release.
- **Consolidate**: `celery.py` is now single source (constants imported from `celery_task_names.py` which stays as single definition site, reliability helpers + `ResilientTask`/`create_celery_app` + `CeleryTaskRegistry`/`TypedCeleryTask` inlined). `celery_reliability.py` and `celery_registry.py` are thin shims `from app.connections.celery import ...` for backward compat. New code must import from `app.connections.celery`.
- **Fix missing `setup_types.py`**: `CogneeSetupConfig` was imported but file missing, breaking `real_celery` (tasks → `agent_memory_tasks` → `cognee_client`); added `src/app/shared/langchain_layer/agents/memory/setup_types.py`.
- **Test harness**: remove `app.connections.celery` mock from `tests/conftest.py` and `test_reliability_system.py` (now that celery is single source, mocking it breaks the shim), lift `app.connections.celery_reliability` in `tests/unit/celery/conftest.py`.

### Verification
- `uv run ruff check src/` — All checks passed
- `uv run ty check src/` — All checks passed
- `uv run pytest tests/unit/celery -q` — 68 passed
- `uv run pytest tests/unit/test_circuit_breaker.py -q` — 7 passed
- Wire format: `serialize_idempotency_record` still produces same JSON keys + ISO-8601 `updated_at`; `from_json` tolerant to old Pydantic JSON.

### Risk
Low — wire format preserved, `Redis` typing aligned with `cache/`, shims keep old imports working. Follow-up: remove shims + `__getattr__` after one release.

### Greptile
Requesting 5/5 confidence — please review for Redis typing, wire-format, and import-cycle regressions.

## Summary by Sourcery

Consolidate Celery infrastructure around a single source of truth while preserving Redis wire compatibility and existing imports.

Bug Fixes:
- Add the missing Cognee setup configuration model so real Celery task imports work correctly.

Enhancements:
- Consolidate Celery application, reliability helpers, and typed task registry into a single canonical module.
- Replace the duplicated Redis protocol and reliability data models with the shared Redis type, JSON payloads, typed dictionaries, and a frozen rate-limit model.
- Preserve compatibility for existing Celery reliability and registry imports through temporary shims and lazy legacy model aliases.

Tests:
- Update Celery test isolation to exercise the consolidated module and compatibility shims without mocking the canonical Celery module.