### PR TITLE
feat(error-handling): foundation — sections 1,2,4,3.1 (26 tasks)

### DIFF
--- a/.ast-grep/fixtures/no-match-on-result/forbid.py
+++ b/.ast-grep/fixtures/no-match-on-result/forbid.py
@@ -1,0 +1,7 @@
+from returns.result import Success, Failure
+result = None
+match result:
+    case Success(value):
+        pass
+    case Failure(error):
+        pass

--- a/.ast-grep/fixtures/no-match-on-result/permit.py
+++ b/.ast-grep/fixtures/no-match-on-result/permit.py
@@ -1,0 +1,5 @@
+from app.features.subscriptions.errors import SubscriptionNotFoundError
+error = None
+match error:
+    case SubscriptionNotFoundError():
+        pass

--- a/.ast-grep/rules/no-match-on-result.yml
+++ b/.ast-grep/rules/no-match-on-result.yml
@@ -8,4 +8,4 @@ note: |
   them, so `.unwrap()` stays untyped. isinstance narrows correctly.
 rule:
   kind: case_pattern
-  regex: ^(Success|Failure)\(\s*\)$
+  regex: ^(Success|Failure)\(

--- a/openspec/changes/error-handling-foundation/.openspec.yaml
+++ b/openspec/changes/error-handling-foundation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-gated
+created: 2026-08-29

--- a/openspec/changes/error-handling-foundation/HANDOFF.md
+++ b/openspec/changes/error-handling-foundation/HANDOFF.md
@@ -1,0 +1,373 @@
+# Handoff — implementing `error-handling-foundation`
+
+You are implementing an OpenSpec change whose planning is **complete and frozen**.
+All six artifacts exist and validate. Your job is `tasks.md`, not re-planning. If you
+believe an artifact is wrong, say so and stop — do not silently deviate.
+
+**State as of 2026-08-31: 26 of 97 tasks done.** Sections 1 (13/13), 2 (7/7) and 4
+(5/5) are complete, plus task 3.1. Verify that yourself with
+`grep -c '^- \[x\]' tasks.md` before trusting this line — it is a snapshot, and the
+count changes as you work. Every completed task carries a `> **DONE:**` block naming
+the sites it touched; keep that convention.
+
+**Section 9 is new** and was added after implementation had already started, when the
+owner brought five previously-excluded directories into scope. It is not blocked by
+anything you have done. Read design **D20** before starting it.
+
+Repo: `Harmeet10000/AgentNexus-LangChain-FastAPI` · default branch `main` ·
+change dir: `openspec/changes/error-handling-foundation/`
+
+---
+
+## 1. Read these first, in this order
+
+```bash
+openspec status --change error-handling-foundation --json
+openspec instructions apply --change error-handling-foundation --json
+```
+
+`status` confirms 6/6 artifacts and names the schema (`spec-gated`).
+`instructions apply` returns `contextFiles` (artifact → real file paths), progress
+counts, the parsed task list, and two fields you must honour:
+
+- `context` — **required** prompt-level input. Project facts and conventions. Apply it.
+- `operationGuidance` — advisory. Follow entries that are applicable and don't
+  conflict with a controlling input (a resolved path, a CLI contract, a user choice).
+
+Then read, in this order: `proposal.md` (why + scope) → `adrs.md` (the six decisions
+you may not relitigate) → `design.md` (D1–D20, Migration Plan) → `review.md` (five
+APPROVED passes; the **Method notes** at the end of passes 2, 3, 4 and 5 are binding on
+how you measure) → `tasks.md` (your work).
+
+Skip `specs/` on first read; consult a capability's `spec.md` when you implement the
+tasks that cite it.
+
+## 2. Which workflow
+
+Use the project's OpenSpec skills. They are in `.opencode/skills/`:
+
+| Phase | Skill | When |
+|---|---|---|
+| Implement | `openspec-apply-change` | working through `tasks.md` |
+| Self-check | `openspec-verify-change` | before opening each PR |
+| Archive | `openspec-archive-change` | **only after the last PR merges to `main`** |
+
+`openspec-continue-change` is for unfinished *planning* — you will not need it.
+Do **not** use `openspec-new-change` or `openspec-propose`; planning is done.
+
+There is no store in play, so never pass `--store`.
+
+## 3. Git: split the remainder, don't ship 97 tasks in one PR
+
+97 tasks in one PR makes bot review useless. Split on the dependency seams the task
+file marks. **Never commit to `main`.**
+
+### What has already landed
+
+Four commits on `feature/error-handling-foundation`, none merged to `main` yet:
+
+| Commit | Covers |
+|---|---|
+| `d5854a0` `fix(repositories): roll back before returning Failure…` | section 1 — 9 repositories |
+| `0ca39ea`, `789b331` `chore(openspec): …` | ticks + `DONE:` blocks for 1.1–1.13 |
+| `58422c1` `feat(result): shared spine + renderer` | sections 2 and 4, **plus task 3.1** |
+
+Sections 2, 4 and task 3.1 arrived in one commit, so the original PR 1 / 2 / 3 split no
+longer maps onto the history — do not try to retrofit it. Open **one PR for the branch
+as it stands** (sections 1, 2, 4, task 3.1 — 26 tasks) and split only what remains:
+
+| # | Branch | Sections | Tasks | Depends on |
+|---|---|---|---|---|
+| A | `feature/error-handling-foundation` (exists) | 1, 2, 4, 3.1 | 26 | nothing — merge first |
+| B | `feat/enforcement-gates` | 3.2–3.11 | 10 | A |
+| C | `feat/subscriptions-exemplar` | 5 | 8 | B |
+| D | `refactor/error-classification-and-docs` | 6, 7, 8 | 23 | A (C not required) |
+| E | `chore/scope-exemptions-and-examples` | 9 | 16 | D — task 9.3 must ship in the same commit as 7.5 |
+
+Section 10 (verification) runs on **every** PR. Section 11 (handoff notes) goes in E.
+
+Task **9.11** is the exception to the table: it is four `# noqa: BLE001` sites in
+`features/subscriptions/service.py`, so do it in C with the rest of the exemplar and
+tick it there.
+
+E is small and mostly configuration, but do not fold it into D — task 9.1 removes
+8 lint suppressions and the findings that surface are the point of the PR. Mixed into a
+23-task refactor, a reviewer cannot tell an uncovered defect from a new one.
+
+**Two things about PR A specifically.** Task 3.1's regex fix to
+`.ast-grep/rules/no-match-on-result.yml` is *correct* — verified both ways, see §6 — but
+it shipped **no fixture pair**, and ADR-005 requires one with every rule this change
+touches. A corrected rule is the exact case that ADR was written for. Add the fixture
+before opening A; do not revert the rule, it works.
+
+And every planning artifact except `tasks.md` is still **untracked** (`proposal.md`,
+`design.md`, `adrs.md`, `review.md`, `specs/`, this file). Commit them in A, or a
+reviewer — and the next agent — gets 97 ticked checkboxes with no plan behind them.
+
+Branch prefixes match the repo's history — `fix/`, `feat/`, `refactor/`, `chore/`.
+Commit messages are conventional-commit scoped, e.g.
+`fix(repositories): roll back before returning Failure from a caught DB exception`.
+
+```bash
+git checkout main && git pull
+git checkout -b feat/enforcement-gates      # or the next branch in the table
+# ... work, commit in logical units ...
+git push -u origin feat/enforcement-gates
+gh pr create --base main --fill
+```
+
+`gh pr create` picks up `.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md`.
+Fill it honestly — tick only the boxes you actually did. Two notes on that template:
+it says `mypy src`, but this project uses **`ty`**, not mypy; and it predates `uv`,
+so use the commands in section 5 below, not the ones in its code block.
+
+In the PR body, always include:
+- which `tasks.md` sections this PR covers, and the task numbers
+- the exact `openspec validate --strict` and gate output (paste it)
+- for PR A: that section 1 is a standalone correctness fix closing live
+  poisoned-commit paths, reviewable without the error redesign
+
+## 4. Waiting for review comments
+
+Two bots auto-review every PR in this repo — **`sourcery-ai`** and
+**`greptile-apps`**. They comment within a few minutes; there is no human gate you
+need to wait on unless the owner asks for one.
+
+```bash
+gh pr checks <n> --watch                 # CI (see §5) — wait for this to go green
+gh pr view <n> --json reviews,comments   # bot reviews + summaries
+gh api repos/Harmeet10000/AgentNexus-LangChain-FastAPI/pulls/<n>/comments \
+  -q '.[] | "\(.path):\(.line) [\(.user.login)] \(.body)"'   # inline line comments
+```
+
+Handling them:
+
+1. Fix what is a real defect. Commit on the same branch and push — the bots re-review.
+2. Where a comment is wrong or conflicts with an ADR, **reply saying which ADR and
+   why**, and do not change the code. Bot reviewers do not know the spec; several of
+   this design's rules look wrong out of context. The two most likely:
+   - a bot will call the flat-sibling duplication "code duplication that should be
+     extracted to a base class" — refusing that is the point of **ADR-001**
+   - a bot will suggest `match` on `Success`/`Failure` — **ADR-002** forbids it, with
+     measured evidence
+3. Re-run section 10 locally after every fix round. Do not push a fix without it.
+4. Merge only when CI is green **and** every bot thread is either resolved or answered.
+
+```bash
+gh pr merge <n> --squash --delete-branch
+```
+
+Squash, so each PR is one commit on `main`. Then `git checkout main && git pull`
+before starting the next branch.
+
+## 5. Validating after implementing
+
+Three layers. Run all three; they do not overlap as much as they look.
+
+### (a) OpenSpec artifact validation
+
+```bash
+openspec validate error-handling-foundation --strict
+openspec status --change error-handling-foundation --json   # task progress
+```
+
+`--strict` checks scenario formatting (`#### Scenario:` — exactly four hashes),
+that every requirement has ≥1 scenario, and delta-block well-formedness. Run it
+after any edit to `tasks.md` (including ticking checkboxes) and before every PR.
+
+Tick `- [x]` as you finish each task. The apply phase parses those checkboxes — an
+untracked task reads as undone.
+
+### (b) The project's own checks — always `uv run`
+
+```bash
+uv lock --check                     # FIRST. See the warning below.
+uv run ruff format src/ tests/
+uv run ruff check --fix src/ tests/
+uv run ty check src/ tests/
+uv run pytest
+ast-grep scan src/
+```
+
+**`uv lock --check` first, and do not run a bare `uv sync`.** The test dependencies
+sit outside `default-groups`, so a bare `uv sync` uninstalls `pytest-asyncio` and
+your suite stops collecting. If `uv lock --check` passes, you need no sync at all.
+If you must sync, use CI's form: `uv sync --extra dev`.
+
+**Note the widths.** `CLAUDE.md` says `src/`; **CI checks `src/ tests/`** for ruff
+and `ty`. Use `src/ tests/` locally or you will pass locally and fail in CI.
+
+**Measure the `ty` baseline before you start**, on a clean checkout. Do not trust a
+count written in any document, including this one. Fixing one shadowed import can
+make the error count *go up*, because `# ty: ignore` comments that were suppressing
+real errors turn dead and become unused-ignore errors.
+
+**`pytest` baseline: 103 pass, 12 pre-existing websocket fixture-drift failures**
+owned by no change here. Verify that baseline yourself on `main` before your first
+commit, then hold it: your PR must not grow the failure count. If CI is already red
+on `main` from those 12, say so in the PR rather than trying to fix them.
+
+Never reach a green check by adding `# noqa` or `# ty: ignore` — task 10.5 forbids it,
+and it forbids adding an entry back to `per-file-ignores` for the same purpose.
+
+### (c) CI (`.github/workflows/test.yml`, runs on every PR to `main`)
+
+Spins up Postgres 16, Mongo 6 and Redis, then in order:
+`uv sync --extra dev` → `ruff check src/ tests/` → `ruff format --check src/ tests/`
+→ `ty check src/ tests/` → `alembic upgrade head` → `alembic heads` →
+**`alembic check`** → `pytest tests/ --cov` → `pytest tests/ -m integration`.
+
+Two things to know. `alembic check` fails on **model drift** — this change touches
+repositories and error types, not ORM models, so it should stay green; if it goes
+red, you changed a model and should not have. And `src/alembic/env.py` imports a
+feature model at runtime, so deleting or moving a model breaks *every* alembic
+command while no test in the suite runs alembic — CI is the only place that catches it.
+
+`-m integration` runs tests the default run deselects, so a green local `pytest` does
+not mean everything ran.
+
+## 6. Gate discipline — ADR-005, non-negotiable
+
+Seven new ast-grep rules and one fix. **A rule is not trusted until you have shown it
+flags the construct it forbids and spares the nearest construct it permits.** Ship a
+fixture pair with each. Register them in `sgconfig.yml`.
+
+`no-match-on-result` **was** broken and task 3.1 has fixed it. Its regex matched only
+the argument-less `Success()` form (`^(Success|Failure)\(\s*\)$`), so
+`case Success(value):` — the exact thing it exists to catch — passed. 3.1 widened it to
+`^(Success|Failure)\(`, which was then verified both ways against a probe: it flags
+`case Success(value)`, `case Failure(err)`, `case Success()` and `case Failure()`, and
+spares `case SubscriptionNotFoundError():` and `case SubscriptionConflictError(code=c):`.
+
+**Re-measured from scratch after the fix: 0 violations in `src/`, 0 in `tests/`** —
+and `rg 'case\s+(Success|Failure)\s*\('` over the same trees independently returns 0,
+so this zero is real, not a rule looking for something nobody writes. Section 3 has no
+existing violations to clean up; its remaining ten tasks are about the *new* rules.
+
+What 3.1 still owes is task **3.2**: a **committed** fixture pair. The verification above was a throwaway
+probe, so nothing in the repo stops a future edit from narrowing the regex again — which
+is precisely the failure ADR-005 exists to prevent. Its severity is also `warning`, not
+`error`, unlike three of the other four rules; decide deliberately which the new rules
+get.
+
+One coverage fact you can rely on, measured the same way: `ast-grep scan` reads **411 of
+the 427** `.py` files under `src/ tests/`, and the 16 it skips are exactly the 16
+zero-byte `__init__.py` files. There is no hidden path exclusion in `sgconfig.yml` —
+unlike ruff, whose exclusions are the subject of the next paragraph.
+
+**ADR-005 has a second form, and it is why section 9 exists.** A rule can also report
+nothing because it was *pointed away from the code*. `pyproject.toml`'s
+`per-file-ignores` disables `BLE001`, `E722`, `B904`, `TRY201`, `TRY300`, `TRY301`,
+`TRY400` and `S112` for `src/app/examples/*.py` — so `ruff check src/app/examples/`
+says "All checks passed!" while `ast-grep`, the only gate there with no per-path
+ignore, reports **4 `error`-level violations** in the same files. Before you cite any
+gate's clean run, read what it was configured to skip. Task 10.7 makes that an explicit
+step; task 9.1 removes the entries.
+
+Six shapes must NOT be flagged by your new rules. Verify each explicitly:
+
+1. `middleware/global_exception_handler.py` — zero `except` blocks; dispatches by registration
+2. an `except ImportError` capability flag
+3. the three `raise TooManyRequestsException` sites in `features/crawler/router.py` — a boolean policy guard, not a rendered failure
+4. `raise ValueError` inside a Pydantic validator (`config/settings.py:473`, `api/strict_envelope.py:26`) and `raise AttributeError` inside a PEP 562 module `__getattr__` (`src/database/__init__.py:37`) — the framework reads those, not project code
+5. a broad `except` carrying a written reason after `# noqa: BLE001` — 55 of the repo's 62 such sites already do
+6. a blind `except` that ends in a bare `raise` (`middleware/server_middleware.py:100`) — nothing was survived, and `BLE001` itself spares this shape
+
+## 7. Four measurement rules from `review.md`
+
+Seven errors in this change's own drafting came from skipping these. They are cheap.
+
+1. **Before a count becomes a claim about a population, enumerate the population a
+   second, structurally different way and reconcile.** `rg -c` summed over files is
+   one query; iterating enumerated members is the other. Where they disagree, the
+   total is usually right and the attribution invented. This one fired again in the
+   fourth pass: a summed count said 6 documented `# noqa: BLE001` sites in `src/tasks/`
+   and the enumeration showed 2 — and the two reconciling queries then agreed on 7
+   reasonless sites repo-wide, which is the number in the spec.
+2. **`ls` the path a plan says it will create, and read the module it says it will
+   extend, before reasoning about its content.** Two review passes missed that
+   `app/shared/result/` already held the "new" vocabulary. And match the probe to the
+   edge kind: `rg <string>; test $? -eq 1` cannot see symbol imports, and
+   `python -c "import x"` cannot see `TYPE_CHECKING` ones.
+3. **Before citing a gate's clean run, read its exclusion list.** A working rule
+   pointed away from the code produces the same zero as a broken rule. `per-file-ignores`,
+   `sgconfig.yml`'s `ruleDirs`, and any rule-level path filter all count.
+4. **You and the branch are two moving objects.** Never state a task total from memory
+   or from another document — derive it twice. `grep -c '^- \[ \] '` counts only the
+   *open* boxes; the total needs `grep -cE '^- \[( |x)\] '`, and a per-section sum is the
+   reconciling second query. And a `DONE` block that says "partial" is a debt nothing
+   collects: `--strict` cannot see it and `openspec status` counts the task complete, so
+   grep the `DONE` blocks for "partial", "deferred" and "TODO" before opening the PR that
+   contains them.
+
+## 8. Archiving — last step, after the last merge
+
+```bash
+git checkout main && git pull
+openspec instructions archive --change error-handling-foundation --json   # advisory
+openspec archive error-handling-foundation
+openspec validate --specs --strict
+```
+
+`archive` folds the delta specs into `openspec/specs/` and moves the change to
+`openspec/changes/archive/`. Do **not** pass `--skip-specs` (this change has real
+spec deltas) or `--no-validate`.
+
+**One archive hazard specific to this change.** It contains a `## REMOVED` block for
+`pattern-matching-standard`'s `match`-on-Result requirement, and a MODIFIED block
+elsewhere. On archive, a MODIFIED block replaces its requirement **wholesale** — an
+omitted scenario is silently deleted and `validate --strict` cannot detect it. Before
+archiving, diff each MODIFIED block against the deployed spec and confirm every
+scenario you meant to keep is present in the block.
+
+Archive in its own commit on `main`, or a small `chore/archive-...` PR.
+
+## 9. Scope boundary
+
+**In scope:** `src/app/{features,connections,lifecycle,middleware,shared,utils}`, plus
+the five directories added after the third review pass — `src/app/api`,
+`src/app/config`, `src/app/examples`, `src/database`, `src/tasks`. Section 9's tasks
+are all of them; design **D20** tabulates every site and its disposition. Most of that
+work is removing an exemption or writing one down, not converting code.
+
+Read D20 before you touch any of the five. Three raises there must stay exactly as
+they are (`config/settings.py:473`, `api/strict_envelope.py:26`,
+`src/database/__init__.py:37`) because a framework, not project code, reads them —
+converting one of those would make an invalid setting validate successfully.
+
+**Explicitly out of scope, by the owner's decision** — do not touch, do not report as
+a coverage gap: `src/mcp_core` (19 modules, 23 raises, 10 `except`). `src/lynk` is
+outside by nature: 24 `.go` files, zero `.py`.
+
+Two tasks reach outside `features/subscriptions/` on purpose and are marked in
+`tasks.md`: **2.6** fixes a kindless `AppError` in `ingestion/service.py:86` because
+the renderer is `kind`'s first consumer, and **section 1** touches nine features'
+repositories because staging the rollback across seventeen changes would leave the
+defect open for the duration. Nothing else may reach outside its section's scope.
+
+## 10. Stop and ask
+
+- An ADR appears wrong. Say which, and why, with the measurement.
+- A task's target does not exist or has moved.
+- `ty` or `pytest` baseline differs materially from §5.
+- Task 2.3 fails — if `ty` does **not** reject a hand-written `ClassVar` code string,
+  the whole ClassVar design is unenforceable. Stop there; do not work around it.
+- A bot review and an ADR conflict and you are unsure which governs.
+
+## 11. What comes after (not yours unless asked)
+
+Phase 1a — `shared/services/`, **before** the `crawler` feature change, because
+`crawler/service.py:18` imports `search` from `tavily.py`. Three modules: `storage`
+(21 raises), `tavily` (8), `mailer` (2, no external importer). `rate_limiter.py` is
+excluded — it raises nothing.
+
+Then 16 feature changes in the order in `design.md`'s Phase 2, then **two** deferred
+changes: `shared/crawler/` alongside the `crawler` feature, and `shared/rag/`'s provider
+boundary alongside `documents`. `utils/cache/` is **not** deferred — it is task 7.5 in
+this change, with `examples/redis_examples.py` in the same commit as task 9.3. An
+earlier draft of `design.md` listed the pair as deferred while its own risk register and
+`tasks.md` both scheduled it here; that line is corrected.
+
+18 features exist, not 17. `subscriptions` migrates in this change as the exemplar, and
+`chat` needs no change at all — `__init__.py` and `model.py`, zero raises, zero
+`except` clauses. That is the whole 18 = 1 + 16 + 1 arithmetic.

--- a/openspec/changes/error-handling-foundation/HANDOFF.md
+++ b/openspec/changes/error-handling-foundation/HANDOFF.md
@@ -64,24 +64,29 @@ file marks. **Never commit to `main`.**
 
 ### What has already landed
 
-Four commits on `feature/error-handling-foundation`, none merged to `main` yet:
+Six commits on `feature/error-handling-foundation`, none merged to `main` yet:
 
 | Commit | Covers |
 |---|---|
 | `d5854a0` `fix(repositories): roll back before returning Failure…` | section 1 — 9 repositories |
 | `0ca39ea`, `789b331` `chore(openspec): …` | ticks + `DONE:` blocks for 1.1–1.13 |
 | `58422c1` `feat(result): shared spine + renderer` | sections 2 and 4, **plus task 3.1** |
+| `853fe25` `chore(openspec): add planning artifacts…` | the six artifacts + a no-match fixture |
+| `7074738` `refactor(db): replace DB_ERROR literals…` | **tasks 7.1 and 7.2 in code — still unticked** |
 
-Sections 2, 4 and task 3.1 arrived in one commit, so the original PR 1 / 2 / 3 split no
-longer maps onto the history — do not try to retrofit it. Open **one PR for the branch
-as it stands** (sections 1, 2, 4, task 3.1 — 26 tasks) and split only what remains:
+Two warnings from that history. `7074738` changed nine repositories and no checkbox, so
+`tasks.md` understates progress: verify 7.1/7.2 against the code before redoing them, and
+tick them with a `DONE:` block once you have. And sections 2, 4 and task 3.1 arrived in
+one commit, so the original PR 1 / 2 / 3 split no longer maps onto the history — do not
+try to retrofit it. Open **one PR for the branch as it stands** and split only what
+remains:
 
 | # | Branch | Sections | Tasks | Depends on |
 |---|---|---|---|---|
-| A | `feature/error-handling-foundation` (exists) | 1, 2, 4, 3.1 | 26 | nothing — merge first |
+| A | `feature/error-handling-foundation` (exists) | 1, 2, 4, 3.1, 7.1–7.2 | 28 | nothing — merge first |
 | B | `feat/enforcement-gates` | 3.2–3.11 | 10 | A |
 | C | `feat/subscriptions-exemplar` | 5 | 8 | B |
-| D | `refactor/error-classification-and-docs` | 6, 7, 8 | 23 | A (C not required) |
+| D | `refactor/error-classification-and-docs` | 6, 7.3–7.7, 8 | 21 | A (C not required) |
 | E | `chore/scope-exemptions-and-examples` | 9 | 16 | D — task 9.3 must ship in the same commit as 7.5 |
 
 Section 10 (verification) runs on **every** PR. Section 11 (handoff notes) goes in E.
@@ -96,13 +101,18 @@ E is small and mostly configuration, but do not fold it into D — task 9.1 remo
 
 **Two things about PR A specifically.** Task 3.1's regex fix to
 `.ast-grep/rules/no-match-on-result.yml` is *correct* — verified both ways, see §6 — but
-it shipped **no fixture pair**, and ADR-005 requires one with every rule this change
-touches. A corrected rule is the exact case that ADR was written for. Add the fixture
-before opening A; do not revert the rule, it works.
+check that its fixture pair is actually committed; ADR-005 requires one with every rule
+this change touches, and a corrected rule is the exact case that ADR was written for.
+That is task 3.2. Do not revert the rule, it works.
 
-And every planning artifact except `tasks.md` is still **untracked** (`proposal.md`,
-`design.md`, `adrs.md`, `review.md`, `specs/`, this file). Commit them in A, or a
-reviewer — and the next agent — gets 97 ticked checkboxes with no plan behind them.
+And **re-check `tasks.md`'s section list before you trust it.** `853fe25` committed the
+planning artifacts, which fixed the original problem — the branch now carries its
+proposal, ADRs and spec deltas rather than bare checkboxes. But the `tasks.md` in that
+commit was the **79-task, 10-section** version: section 9, the renumbering, and tasks
+10.7 and 11.5 had been lost from it while the specs kept all 45 requirements. Restored
+since. `grep -n '^## ' tasks.md` must show `## 9. The five later-added directories`,
+`## 10. Verification`, `## 11. Handoff`, and 97 total checkboxes. If it shows
+`## 9. Verification`, you are on the narrowed copy and section 9's 16 tasks are missing.
 
 Branch prefixes match the repo's history — `fix/`, `feat/`, `refactor/`, `chore/`.
 Commit messages are conventional-commit scoped, e.g.

--- a/openspec/changes/error-handling-foundation/adrs.md
+++ b/openspec/changes/error-handling-foundation/adrs.md
@@ -1,0 +1,277 @@
+# Architectural Decision Records — `error-handling-foundation`
+
+Six decisions from `design.md` outlive this change: other parts of the system build
+on them, or a future reader will otherwise re-litigate a trade-off that was settled
+by measurement. The remaining twelve decisions arrange existing pieces and stay in
+`design.md`.
+
+---
+
+## ADR-001 — Error classification is a class constant on a closed per-feature union
+
+- **Date:** 2026-08-29
+- **Change:** `error-handling-foundation`
+- **Status:** Accepted
+
+**Context.** `AppError` is an open Pydantic hierarchy whose `code` is a field with a
+default. Any construction site can invent or mistype a code, and 118 off-enum
+literals emitting 68 distinct codes against an 18-member enum is what that shape
+produced. Because anyone can subclass the base anywhere, no type checker can
+enumerate the subclasses, so no dispatch over the hierarchy can ever be proven
+total.
+
+**Decision.** `kind`, `code` and `retryable` are `ClassVar` on a frozen
+`extra="forbid"` Pydantic base, never constructor parameters. Each feature — and each
+shared module that classifies a third-party exception — declares its own `<Owner>Code`
+StrEnum, its concrete error types as flat siblings with no inheritance between them,
+and a closed `type <Owner>Error = A | B | C` union in its own `errors.py`.
+
+**Rationale / Alternatives.** Measured with the project's `ty`:
+`code: ClassVar[SubscriptionCode] = "DUPLICATE_SUBSCRIPTION"` is rejected as
+`error[invalid-assignment]` *even though the string value is correct*. A code cannot
+be spelled by hand at all — right or wrong — which is a stronger guarantee than a
+validator or a lint rule can give. Keeping `code` a field with an enum annotation was
+rejected because a default makes the field optional at every call site; a global enum
+was rejected because it is the cross-cutting coupling this design removes.
+
+The flat-sibling constraint is the non-obvious half. `match`'s class patterns are
+`isinstance`-based, so a broader arm placed before a narrower one makes the narrower
+arm dead — and the type checker still reports the match exhaustive, because from its
+view every case was covered. It has no concept of *reached but shadowed*. 28 such
+chains already exist in the codebase.
+
+**Consequences.**
+- A mistyped or wrong-enum code is a type error, not a runtime surprise or a
+  client-visible string.
+- Adding a failure mode means editing the union, which makes every `match` over it
+  fail to compile until the new arm is handled. That is the intended cost.
+- No type-checker backstop exists for the flat-sibling rule; it is enforced by an
+  ast-grep gate, which is why ADR-005's verification obligation is not optional.
+- `extra="forbid"` turns a stale `code=` keyword into a runtime `ValidationError`
+  raised inside an `except` block, where it can mask the original error. `ty` catches
+  it statically first; the runtime failure is the second line of defence.
+
+---
+
+## ADR-002 — `isinstance` opens the `Result`; `match` dispatches the error union
+
+- **Date:** 2026-08-29
+- **Change:** `error-handling-foundation`
+- **Status:** Accepted
+
+**Context.** The deployed `pattern-matching-standard` spec mandated `match`/`case` on
+`Success`/`Failure` and forbade `isinstance`. The project's own ast-grep gate, its
+instruction docs and 122 unwrap call sites do the opposite. Something had to give,
+and the question was which.
+
+**Decision.** Code unwrapping a `Result` uses `isinstance(result, Failure)`. `match`
+is reserved for the error union obtained *after* that narrowing, closed with
+`assert_never`.
+
+**Rationale / Alternatives.** This is settled by measurement, not taste. On this
+repository's `ty`:
+
+| Construct | Verdict |
+|---|---|
+| `match result: case Success(value)` | **no narrowing** — binds the union of success *and* error types |
+| `isinstance(result, Failure)` then `.failure()` | narrows to the error union |
+| `match error:` over a closed union + `assert_never` | passes |
+| same, one arm removed | `error[type-assertion-failure]` naming the missing type |
+
+Exhaustiveness checking is real and worth having — it just belongs on the error
+union, not on the `Result` container. Once that distinction is drawn the apparent
+conflict dissolves: the gate and the spec were describing different constructs.
+Mandating `match` on the container would have cost narrowing at 122 sites for no
+benefit; banning `match` outright would have given up `assert_never`, which is the
+mechanism the whole closed-union design leans on.
+
+**Consequences.**
+- The deployed spec's requirement is REMOVED rather than MODIFIED: a MODIFIED header
+  must stay byte-identical, which would archive a header asserting `match` above a
+  body mandating `isinstance`, permanently.
+- The `no-match-on-result` gate must reject `case Success(value):` while accepting
+  `case SubscriptionNotFoundError():`. A pattern careless about that distinction
+  would flag the endorsed construct at every dispatch site in the system.
+
+---
+
+## ADR-003 — `ErrorKind` is a seven-member, fixed-width boundary vocabulary
+
+- **Date:** 2026-08-29
+- **Change:** `error-handling-foundation`
+- **Status:** Accepted
+
+**Context.** Per-feature unions solve drift inside a feature but leave every boundary
+adapter — HTTP renderer, Celery task, MCP handler, auth dependency — needing to act
+on an error whose concrete type it cannot know. Scoping agreed five kinds:
+`VALIDATION`, `NOT_FOUND`, `CONFLICT`, `INFRASTRUCTURE`, `EXTERNAL_SERVICE`.
+
+**Decision.** Seven: the agreed five plus `AUTHENTICATION` (401) and `AUTHORIZATION`
+(403). It is the only vocabulary shared across features, and boundary dispatch is
+over `kind`, never over a concrete error type.
+
+**Rationale / Alternatives.** Five members cannot express 401 or 403.
+`auth/service.py` raises `UnauthorizedException` at 16 sites, and the locked scope
+converts every service to Result-typed — so with five kinds a failed login would have
+rendered **422**. The old `ErrorCode` covers this correctly (`UNAUTHORIZED`,
+`FORBIDDEN`, `INVALID_TOKEN`, `TOKEN_EXPIRED`, `REFRESH_TOKEN_INVALID`), so the
+five-member design was a regression against shipped behaviour, on the feature
+scheduled last and therefore discovered latest. Carving `auth` out of the conversion
+contradicts the locked scope; letting an error carry an explicit status reintroduces
+the per-endpoint drift being removed.
+
+Seven keeps the property that mattered: dispatch width is independent of how many
+concrete error types exist. Seventeen features can add error types indefinitely and
+every adapter still has the same seven arms.
+
+**Consequences.**
+- Boundary adapters are stable under feature growth.
+- Adding a kind is a breaking change for every adapter, which is the correct
+  friction — it is a change to the system's shared vocabulary.
+- Status is derived from `kind`, refined by `retryable` only for `INFRASTRUCTURE`
+  (500 when dead, 503 when transient).
+- The near-miss is the argument for auditing a plan against the ground rather than
+  the reverse. It was found by measurement during review, before any code.
+
+---
+
+## ADR-004 — The router renders; the renderer owns the transport status
+
+- **Date:** 2026-08-29
+- **Change:** `error-handling-foundation`
+- **Status:** Accepted
+
+**Context.** `http_error()` writes a status *into the response body* and does not set
+the HTTP status. Returning it from a route therefore yields **HTTP 200** with
+`"success": false` — a body that says 404 delivered with a 200. The alternative in
+use is `raise app_error_to_exception(error)`, which an existing gate flags at 34
+sites as retired.
+
+**Decision.** One shared `render_result(result, response, message=...,
+success_status=...)`. On `Failure` it sets `response.status_code` from
+`STATUS_BY_KIND[error.kind]` and returns the `http_error` envelope. Endpoints cannot
+override the failure status.
+
+**Rationale / Alternatives.** Raising from the router keeps the exception path the
+whole change is retiring and makes the router's return type a lie. Letting each
+endpoint pass a failure status is how the current drift happened — 67 call sites
+each deciding independently. Deriving it from `kind` means the status is a
+consequence of classification, and classification is already a type-checked
+`ClassVar`.
+
+The parameter is named `success_status`, not `status_code`: at a call site
+`status_code=201` reads as the status of the response being rendered, which is
+exactly wrong on the failure path.
+
+**Consequences.**
+- The envelope shape does not change; `APIResponse` + `http_error()` survive. Only
+  the transport status is added.
+- A route wanting a non-standard failure status must change the error's `kind`, which
+  is a visible edit to the feature's contract rather than a local override.
+- Endpoints no longer import a feature's error types to render them — the renderer
+  needs only `kind`.
+
+---
+
+## ADR-005 — A gate is not trusted until it is shown to permit and to forbid
+
+- **Date:** 2026-08-29
+- **Change:** `error-handling-foundation`
+- **Status:** Accepted
+
+**Context.** Two of this design's central guarantees have no type-checker backstop: a
+union is closed only because a rule forbids subclassing the base elsewhere, and a
+sibling set is flat only because a rule says so. Both rest entirely on ast-grep.
+
+Then `no-match-on-result` turned out not to work. Its pattern is
+`regex: ^(Success|Failure)\(\s*\)$` against a `case_pattern`, matching only the
+argument-less form — so `case Success(value):`, the exact construct the superseded
+spec mandated and this design forbids, passes unflagged. Its message says match/case
+does not narrow `Result`. Its zero-violation count meant "the rule looked for
+something nobody writes".
+
+**Decision.** Every rule this work introduces or changes ships with a fixture holding
+the construct it forbids *and* the nearest construct it permits, and must be shown to
+flag the first and spare the second before any count derived from it is cited. A
+rule's message must describe what its pattern actually matches. A count from a
+corrected rule is re-measured, never carried forward.
+
+**Amended after the fourth review pass — a gate has two ways to report nothing.** The
+above catches a rule whose *pattern* is wrong. It does not catch a working rule that was
+*pointed away from the code*. `pyproject.toml`'s `per-file-ignores` disables `BLE001`,
+`E722`, `B904`, `TRY201`, `TRY300`, `TRY301`, `TRY400` and `S112` for
+`src/app/examples/*.py` — eight of the rules this change is about — so
+`ruff check src/app/examples/` reports "All checks passed!" while `ast-grep scan`, the
+only gate there with no per-path ignore, reports **4 `error`-level violations** in
+`redis_examples.py`. A broken pattern and a configured exclusion produce the identical
+artefact: a clean run that reads as coverage. So the decision extends: **a gate's clean
+run may not be cited until its exclusion list has been read** — `per-file-ignores`,
+`sgconfig.yml`'s `ruleDirs`, and any rule-level path filter.
+
+**Rationale / Alternatives.** Reviewing rules by reading them is what produced the
+broken one. An unverified gate is indistinguishable from no gate while reading as
+coverage, which is worse than an absent gate because it stops anyone looking. The
+same holds for an excluded path, with one aggravating difference: the exclusion is
+usually deliberate and old, so nobody re-examines whether its reason still applies.
+
+**Consequences.**
+- Seven new rules cost seven fixture pairs. That is the price of the closed-union
+  guarantee, not overhead on top of it.
+- Historical violation counts from unverified rules are not evidence and are not
+  cited as baselines.
+- The same discipline extends to measurement, not just gates: before a count becomes
+  a claim about a population, the population is enumerated by a second, structurally
+  different query and the two reconciled. Four errors in this change's own drafting
+  came from skipping that step.
+- The eight `per-file-ignores` entries for `src/app/examples/*.py` are removed (task
+  9.1) and the findings that surface are fixed, not re-suppressed. Task 10.5 forbids
+  adding an entry back to reach a green check, and task 10.7 makes reading the
+  exclusion lists an explicit verification step.
+- One shape must be **spared** on this reasoning rather than flagged: `BLE001` does not
+  fire on a blind `except` that ends in a bare `raise`, because nothing was survived.
+  A new degradation gate that flags `middleware/server_middleware.py:100` would
+  contradict a tool the project already runs.
+
+---
+
+## ADR-006 — A union is owned by whoever classifies the exception, not by `features/`
+
+- **Date:** 2026-08-29
+- **Change:** `error-handling-foundation`
+- **Status:** Accepted
+
+**Context.** The first draft of this design keyed the error contract on `features/`
+and described its layer classification as total. It was not.
+`src/app/shared/services/` is four third-party wrappers — boto3, httpx — with 31
+raises of `APIException` subclasses and 20 catches, every one of a library type, and
+no `Result` anywhere. Structurally it is indistinguishable from a feature repository:
+it owns a boundary, catches a library's taxonomy, and decides what that means. A
+directory-keyed rule could not see it. Nor could it see the dispatcher every error
+passes through, or the session dependency the rollback requirement exists to protect.
+
+**Decision.** The module that classifies a third-party exception owns the union it
+classifies into, on the same terms as a feature: its own StrEnum, flat siblings,
+closed union, no cross-module code imports. `features/` is the common case, not the
+definition. Layers are classified by the role they play — domain classifier,
+dispatcher, session dependency, degradation boundary, vocabulary — and not living
+under `features/` is never grounds for exemption.
+
+**Rationale / Alternatives.** Leaving `shared/services/` raising `APIException` would
+force any feature that calls it to `try`/`except` around a call the project owns —
+the one thing the try/except rule forbids. A single global `SharedError` union
+reintroduces the cross-cutting coupling ADR-001 removes: a storage failure and a
+Tavily failure share nothing but the word "shared". Moving the modules under
+`features/` would make the directory lie about what they are.
+
+**Consequences.**
+- Ordering constraint, not a preference: `shared/services/` must be Result-typed
+  before `crawler`, its first consuming feature, or that feature violates the
+  try/except rule by construction.
+- The rule cuts both ways and keeps scope bounded. A module that classifies nothing
+  owes nothing — an `except ImportError` that sets an availability flag is capability
+  detection, not error handling, and `shared/rag/`'s pipeline stays exception-native
+  while only its provider boundary converts.
+- `ErrorKind` is unaffected: shared modules classify into the same seven kinds, so
+  ADR-003's fixed-width property holds.
+- The blind spot was found by the request's author, not by the plan — the second
+  directory-shaped assumption in this change to have hidden live error-handling code.

--- a/openspec/changes/error-handling-foundation/design.md
+++ b/openspec/changes/error-handling-foundation/design.md
@@ -1,0 +1,718 @@
+> Change class: **L**
+
+## Context
+
+See `proposal.md` — Why for motivation and the measured defect counts. This
+section records only what constrains the approach.
+
+**Four generations of the same rule are live simultaneously.** Every one of them
+is written down somewhere authoritative:
+
+| Artifact | What it says | Generation |
+|---|---|---|
+| `openspec/specs/pattern-matching-standard/spec.md` | `match`/`case` on `Success`/`Failure` SHALL be used; `isinstance` SHALL NOT | oldest, never implemented |
+| `.kiro/steering/RESULT-PATTERN.md` | `isinstance` + `raise app_error_to_exception(error)` | superseded; the raise is gated as retired |
+| `.opencode/instructions/RESULT-PATTERN.md`, `docs-site/…/error-and-result-pattern.mdx`, `.ast-grep/rules/` | `isinstance` + `http_error()` | current, and what the code does |
+| this change | `isinstance` to open, `match` on the closed error union, render with a real status | target |
+
+The code is unanimous — 122 `isinstance(result, Failure)` sites, zero
+match-on-`Result` — so no generation of the *code* is in dispute. Only the
+governance is.
+
+**Constraints the design must respect:**
+
+- **`ty` does not narrow through `case Success(value)`.** Measured on this
+  repository: the bound name takes the union of the success and error types. Any
+  design built on matching the container is unchecked in precisely the place the
+  pattern was adopted for safety.
+- **`ty` does verify exhaustiveness over a closed union** closed by
+  `assert_never`, reporting `type-assertion-failure` and naming the uncovered
+  member. This is the only static guarantee available, and the design is built to
+  earn it.
+- **`ty` cannot see a shadowed `match` arm.** A broader class pattern before a
+  narrower one makes the narrower unreachable and the match still type-checks as
+  exhaustive. The repo already manages this by hand: the public docs describe
+  `mappers.py` as ordering arms "most-specific first" with a "catch-all
+  `AppError()` at the end". That is a maintenance obligation carried in prose.
+- **`http_error()` does not set a transport status.** It writes the status into
+  the body and returns a plain object, so returning it from a route yields HTTP
+  200 with `"success": false`.
+- **The request-scoped session commits on clean exit and rolls back only on an
+  escaping exception.** A service that swallows a `Failure` therefore reaches
+  `commit()` on a poisoned session. No repository rolls back; `session.rollback`
+  has never appeared under `src/app/features/`.
+- **Baseline is not green.** Recorded below so a reviewer can distinguish a
+  regression from an inheritance.
+
+| Gate | Baseline | Owned by this change? |
+|---|---|---|
+| `uv run ruff check src/` | clean | — |
+| `uv run ty check src/` | 2 errors (`…agents.memory.setup_types` unresolved) | no |
+| `ast-grep scan src/` | 4 errors, 34 warnings | yes — the 34 are `no-raise-app-error-mapper`; the 4 are `no-raw-httpexception` in `examples/redis_examples.py` |
+| `uv run pytest` | 400 of 439 collected, 2 collection errors, 12 known websocket fixture failures | no |
+
+## Goals / Non-Goals
+
+**Goals (design-level):**
+
+- Make the `"DB_ERROR"` class of defect *unrepresentable*, not merely forbidden.
+  A rule a reviewer must remember has already failed 56 times.
+- Buy one static guarantee — exhaustiveness over each feature's failure modes —
+  and keep the mechanism that buys it small enough to hold in mind.
+- Keep boundary code a fixed-width dispatch. Adding a feature error type must not
+  require touching any boundary.
+- Leave every exception-native layer alone, but leave none of them undefined.
+
+**Non-Goals (design-level):**
+
+- A universal error base shared across features. The shared vocabulary is
+  deliberately seven enum members and nothing else.
+- Eliminating exceptions. Raising is correct where control flow must be abandoned
+  rather than answered.
+- A generic classification helper. Which library exception maps to which typed
+  error is feature knowledge; centralising it would recreate the open hierarchy
+  in helper form.
+
+## Decisions
+
+### D1 — `isinstance` opens the container; `match` dispatches the union
+
+**Chosen:** two different constructs for two different jobs.
+
+```python
+result = await self._repo.find(sub_id)
+if isinstance(result, Failure):
+    error = result.failure()          # narrowed: SubscriptionError
+    match error:
+        case SubscriptionNotFoundError():   ...
+        case SubscriptionDuplicateError():  ...
+        case SubscriptionDbError():         ...
+        case _ as unreachable: assert_never(unreachable)
+subscription = result.unwrap()        # narrowed: Subscription
+```
+
+**Alternatives considered:**
+
+| Option | Why not |
+|---|---|
+| `match` on `Success`/`Failure` (the deployed spec's rule) | `ty` binds the union of both sides; the following code is unchecked. Also contradicts three other artifacts and 122 call sites. |
+| `.map()` / `.bind()` combinator chains | Reads well for pipelines, but the failure classification this change exists to enable needs the error *in hand*, and combinator chains hide it. |
+| `isinstance` chains on the error too | Works, but nothing forces completeness — which is the entire point. |
+
+The apparent conflict between the user's design (built on `match`) and the
+`no-match-on-result` gate dissolves here: the gate forbids matching the
+*container*, and the design needs to match the *union*. Both are satisfied
+without compromise.
+
+### D2 — classification is a `ClassVar`, not a field
+
+**Chosen:** `kind`, `code`, `retryable` as `typing.ClassVar` on the error type,
+with `model_config = ConfigDict(extra="forbid", frozen=True)`.
+
+Verified at runtime before committing to it: the constants are absent from
+`model_fields`, absent from `model_dump()`, passing `code=` as a keyword raises
+`ValidationError`, and mutation raises `ValidationError`.
+
+**Alternatives considered:**
+
+| Option | Why not |
+|---|---|
+| Field with a default (**today**) | Every construction site may override or invent a value. This produced 68 distinct codes against an 18-member enum. The type is shaped to permit exactly the bug. |
+| `kind: Literal["not_found"]` per subclass (**also today**) | Present on `AppError` subclasses and read by nothing. Because the base declares no `kind`, it is not a discriminated union and buys no narrowing. |
+| `@property` returning a constant | Works, but is overridable by a subclass and invisible to `extra="forbid"`. `ClassVar` makes the override site the only place it can change. |
+
+`code` is typed as the feature's StrEnum rather than `str`, so a typo is an
+assignment error at the declaration, not a string in a client's response body.
+
+### D3 — one `<Feature>Code` StrEnum per feature, no global enum
+
+**Chosen:** each `errors.py` declares its own enum. No feature imports another's.
+
+The global 18-member `ErrorCode` is the artifact that failed: it was too small to
+cover 18 features, so call sites invented literals instead of extending it.
+Growing it to 68+ members would make it unreviewable and every feature a
+stakeholder in every other feature's additions.
+
+**Trade-off accepted:** the same logical condition may get two names in two
+features (`SubscriptionCode.NOT_FOUND`, `InvoiceCode.NOT_FOUND`). This is the
+cost of independence, and `ErrorKind` supplies the cross-feature vocabulary that
+boundary code actually needs.
+
+### D4 — `ErrorKind` is seven members, and the only shared error vocabulary
+
+`VALIDATION | NOT_FOUND | CONFLICT | AUTHENTICATION | AUTHORIZATION |
+INFRASTRUCTURE | EXTERNAL_SERVICE`.
+
+**This is a deliberate deviation from the five-member set agreed at scoping, forced
+by measurement.** `src/app/features/auth/service.py` raises
+`UnauthorizedException` at **16 sites** — invalid credentials, invalid token,
+expired token, session-owner mismatch. The locked scope converts every feature
+service to Result-typed, so all 16 become typed failures rendered by
+`render_result`. With five members the only reachable statuses are 422, 404, 409,
+502 and 500/503: a failed login would be answered **422**, and a permission denial
+would be indistinguishable from it. The superseded system handles this correctly —
+`ErrorCode` carries `UNAUTHORIZED`, `FORBIDDEN`, `INVALID_TOKEN`, `TOKEN_EXPIRED`,
+`REFRESH_TOKEN_INVALID` — so shipping five members would be a security-boundary
+regression, discovered at the *last* scheduled feature after 16 changes of false
+confidence.
+
+**Alternatives considered:**
+
+| Option | Why not |
+|---|---|
+| Keep five members; carve `auth` out of the Result conversion | Contradicts the locked scope, and makes the one security-critical feature the one feature with no exhaustiveness guarantee. |
+| Keep five; let an auth error carry an explicit status | Contradicts D6 and reinstates per-error status drift — the thing being removed. |
+| Keep five; map `AUTHENTICATION` onto `VALIDATION` | Answers a failed login with 422. Wrong for clients, wrong for monitoring, and wrong for anything counting auth failures. |
+
+Two extra members cost nothing structurally: boundary dispatch stays fixed-width
+at seven arms, independent of how many feature error types exist. They are kept
+separate from each other because 401 and 403 are different client contracts —
+"authenticate" versus "do not retry, you will never be allowed".
+
+Boundary adapters dispatch on `kind`; feature logic dispatches on the concrete
+type. This split is what keeps boundary code fixed-width: `STATUS_BY_KIND` has
+seven entries whether the system has 40 error types or 400. Two error types
+sharing a `kind` can still need opposite handling inside a feature, which is why
+feature logic must not dispatch on `kind`.
+
+### D5 — status derives from `kind`, refined by `retryable`
+
+`VALIDATION` → 422, `NOT_FOUND` → 404, `CONFLICT` → 409, `AUTHENTICATION` → 401,
+`AUTHORIZATION` → 403, `EXTERNAL_SERVICE` → 502, `INFRASTRUCTURE` → 503 if
+`retryable` else 500.
+
+This is the fix for the sharpest live defect. `InfrastructureAppError` defaults
+`retryable=True`, so all 56 `"DB_ERROR"` sites currently answer **503** — telling
+the client to retry a transaction that has already failed and, after this change,
+been rolled back. A rolled-back write declares `retryable = False`.
+
+### D6 — the renderer sets the transport status; endpoints cannot override it
+
+`render_result(...)` accepts any feature's `Result`, sets `response.status_code`
+from `STATUS_BY_KIND`, and emits the existing envelope. It takes a **success**
+status and a success message; it takes **no** failure-status parameter.
+
+The success-status parameter is named `success_status`, not `status_code`. The
+sketch agreed at scoping used `status_code=`, which at a call site reads as
+though it governs the failure — the opposite of what it does. At 67 endpoints
+that ambiguity would be misread, and a misread would look like it worked.
+
+**Alternative considered:** let endpoints pass a status per failure. Rejected —
+that is how 67 endpoints acquire 67 opinions about what a conflict means, and the
+per-endpoint drift is the thing being removed.
+
+Endpoints keep returning the same envelope the global handler produces, so a
+client cannot tell which produced a given response.
+
+### D7 — no inheritance among concrete error types
+
+Every concrete type inherits `FeatureError` directly and nothing else. Shared
+fields are repeated, or promoted to `FeatureError` when genuinely universal.
+
+This is the one rule with no static backstop, which is why it is gated rather
+than documented. `ty` reports a shadowed match exhaustive; there is no runtime
+symptom either. The failure mode is the wrong branch's side effects — a refund
+issued for a validation error, a retry scheduled for a permanent fault.
+
+**Cost accepted:** 28 concrete-inherits-concrete chains exist today (19 under
+`APIException`, 9 outside). They are flattened per feature, in the change that
+migrates that feature.
+
+### D8 — rollback lives in the repository
+
+**Alternatives considered:**
+
+| Option | Why not |
+|---|---|
+| Roll back in the service | The service does not know whether a statement was issued, and a service that swallows the `Failure` is exactly the case that breaks today. |
+| Roll back in `get_postgres_db` | Its `except` only fires when an exception escapes. A returned `Failure` is not an exception, so this path is unreachable for the defect. |
+| Make services always raise so the dependency's rollback fires | Reinstates the retired raise pattern and makes correctness depend on never swallowing a failure. |
+
+The repository catches the exception, so the repository is the only layer that
+knows a rollback is owed. Order: classify → rollback → log → return, so a logging
+failure cannot leave the session poisoned.
+
+**The rule is per-store, not per-repository.** Of 11 repository modules, 9 are
+relational and carry 74 SQLAlchemy handlers; `users/repository.py` catches nothing;
+and `auth/repository.py` is a **document-store repository** — `UserRepository` and
+`RefreshTokenRepository` over MongoDB and Redis, with 13 `PyMongoError`/
+`DuplicateKeyError` handlers and 6 `RedisError` handlers, and no statement on the
+SQLAlchemy session. It has no transaction to roll back, so the rollback obligation
+does not reach it; the classification obligation does.
+
+That split matters beyond bookkeeping, because it splits the `"DB_ERROR"`
+correction too. 49 of the 56 literals are relational, where the transaction is dead
+and 503 → 500 is the fix. The other 7 are in `auth/repository.py` and describe Mongo
+or Redis being unreachable — genuinely retryable, correctly 503. Applying one
+correction to all 56 would have relabelled a retryable outage as a permanent failure
+on the login path. One string was carrying two failure modes, which is the same
+defect as `redis_func.py` raising `DatabaseException` for Redis, arrived at from the
+opposite direction.
+
+### D9 — log at construction only when an exception was involved
+
+Inside an `except` block, log — something threw, and the stack context is here and
+nowhere else. For a plain `if` / `is None` check, do not log: a not-found is often
+ordinary control flow (a first upload rather than a duplicate), and logging every
+one converts normal branching into incident noise.
+
+**Alternative considered:** log in `FeatureError.__init__` uniformly. Rejected —
+it cannot distinguish the two cases, and it puts I/O in a constructor.
+
+### D10 — `app_error_to_exception` survives, narrowed
+
+It is not deleted. Raising boundaries still need it — auth dependencies, WebSocket
+sessions, Celery tasks, MCP handlers. What is retired is calling it from a
+repository or service, which is what `no-raise-app-error-mapper` already flags at
+34 sites.
+
+### D11 — no feature carries two error systems
+
+A feature's old exception classes are deleted in the same change that replaces
+their last call site. A half-migrated feature with both systems live is worse than
+either system alone: two vocabularies for one failure, and no exhaustiveness,
+since the old classes remain constructible.
+
+Repo-wide, both systems coexist while the 16 remaining features migrate. That is
+acceptable — the boundary between them is a feature directory, which is a boundary
+a reader can see.
+
+### D12 — enforcement is gates, not review
+
+A closed union is closed only if nothing subclasses the base outside the feature's
+`errors.py`. That property cannot be maintained by attention. Rules added or
+rewritten:
+
+| Rule | Checks |
+|---|---|
+| `no-match-on-result` (rewrite) | currently matches only the empty `case Success()` / `case Failure()` form, so `case Success(value):` passes unflagged — it does not enforce what its message claims |
+| `no-raise-app-error-mapper` (keep) | 34 outstanding violations retire as features migrate |
+| `error-inherits-feature-error-directly` (new) | D7 — concrete types are flat siblings |
+| `error-classification-is-classvar` (new) | D2 — `kind`/`code`/`retryable` are never fields |
+| `feature-error-in-union` (new) | a concrete type declared but absent from the union |
+| `repository-rollback-on-db-except` (new) | D8 |
+| `no-cross-feature-error-import` (new) | D3 |
+| `no-new-app-error-subclass` (new) | D13 — the retired hierarchy may only shrink |
+| one rule per classified boundary | the layer table in `result-layer-boundaries` |
+
+### D13 — the `AppError` hierarchy is frozen, not merely deprecated
+
+No new `AppError` subclass and no new field on an existing one, from this change
+until the last feature migrates. New error types are declared as `FeatureError`
+subclasses in a feature's `errors.py`.
+
+Deprecation-in-place fails here for a specific reason: the migration spans 17
+changes, and during that window adding to the old hierarchy is locally reasonable
+— the feature has not migrated yet, the old types are what it uses. Each such
+addition is individually defensible and collectively makes the hierarchy grow
+while it is supposed to be retiring. A gate converts "please don't" into "you
+can't", and makes the subclass count a monotonically decreasing number that
+reaching zero is the migration's completion signal.
+
+### D14 — every gate is verified against a permit case and a forbid case
+
+No gate is trusted, and no count derived from a gate is cited, until the rule has
+been shown to flag the construct it forbids and to leave the nearest permitted
+construct alone.
+
+This is a direct response to what `no-match-on-result` turned out to be. Its
+message says match/case does not narrow `Result`; its pattern is
+`regex: ^(Success|Failure)\(\s*\)$` against a `case_pattern`, which matches only
+the argument-less form. `case Success(value):` — the form the superseded spec
+mandated, and the form this design forbids — sails through. Its zero-violation
+count reads as "the codebase is clean" and means "the rule looked for something
+nobody writes".
+
+The risk this creates is specific and worth naming: the rewritten rule must reject
+`case Success(value):` while accepting `case SubscriptionNotFoundError():`, because
+this design forbids the first and *requires* the second. A pattern careless about
+that distinction would flag the endorsed construct at every dispatch site in the
+system.
+
+### D15 — a union is owned by whoever classifies the exception, not by `features/`
+
+The rule is: the module that catches a third-party exception owns the union it
+classifies into. `features/` is the common case, not the definition.
+
+This was forced by measurement. `src/app/shared/services/` — `storage.py` (boto3),
+`tavily.py` (httpx), `mailer.py`, `rate_limiter.py` — has 31 raises of `APIException`
+subclasses and 20 `except` clauses, **every one of them a third-party type**, and no
+`Result` anywhere. Structurally it is indistinguishable from a feature repository: it
+owns a boundary, it catches a library's taxonomy, it decides what that means. A
+classification keyed on directory left it, `shared/rag/` (70 sites) and
+`shared/crawler/` outside the contract while calling the contract complete.
+
+| Alternative | Why not |
+|---|---|
+| Leave `shared/services/` raising `APIException` | A feature calling it must then `try`/`except` around an owned call — the exact thing `result-layer-boundaries` forbids — so the feature's own union would be incomplete for failures it must handle |
+| Give them a single global `SharedError` union | Reintroduces the cross-cutting enum D3 removes; a storage failure and a Tavily failure share nothing but the word "shared" |
+| Move them under `features/` | They have no router, no repository, no table; the directory would lie about what they are |
+| **One union per classifying module** | Same rule as a feature, applied by role. `storage.py` owns storage codes, `tavily.py` owns search codes, and neither imports the other |
+
+The consequence for `ErrorKind` is nil: these modules classify into the same seven
+kinds, so the boundary dispatch stays fixed-width.
+
+### D16 — the session dependency is pinned, not widened
+
+`get_postgres_db` keeps exactly its current shape and is explicitly forbidden from
+inspecting a `Result`.
+
+`src/app/connections/postgres.py:241` yields the session, commits on clean exit, and
+rolls back only inside `except Exception`. A returned `Failure` is not an escaping
+exception, so when a service swallows one the `except` never fires and `commit()`
+runs on a failed transaction. The obvious-looking fix is to make the dependency
+smarter. It cannot be: at the point it commits, it has no reference to any `Result`
+and has seen no exception. There is nothing for it to inspect.
+
+| Alternative | Why not |
+|---|---|
+| Have the dependency inspect a returned `Result` | It has no access to one. Threading it there would couple a transport-agnostic dependency to the domain error type |
+| Always roll back and require explicit commits | Inverts the contract at 63 call sites for a defect that belongs one layer down; every read path pays for it |
+| Add a second rollback in the dependency's `finally` | Rolls back successful work; `finally` cannot tell the two apart |
+| **Pin the dependency, roll back in the repository** | The repository is the only layer that knows a statement was issued, which is D8's reasoning arrived at from the other side |
+
+Writing this down as a requirement matters because "make the session dependency
+handle it" is the first idea every reader has, and it is unimplementable for a
+reason that is not obvious from the dependency's own source.
+
+### D17 — the global dispatcher is exempted, not conformed
+
+`middleware/global_exception_handler.py` keeps its `isinstance` chain over framework
+exception types, and no rule this change introduces may flag it.
+
+The types it dispatches on are framework-owned and their inheritance is load-bearing:
+`APIException` derives from `HTTPException`, and lines 166–200 of that file record
+what happened when the registration was simpler. Starlette splits
+`add_exception_handler` across two middlewares and routes the `Exception` key to a
+different one than every other key; FastAPI pre-seeds `setdefault(HTTPException,
+http_exception_handler)`, so the MRO walk for `ServiceUnavailableException` hit
+FastAPI's entry three classes early and returned `{"detail": ...}` — the elaborate
+`APIException` branch never executed for any member of the family. Starlette's and
+FastAPI's `HTTPException` are also different classes. The comment ends by instructing
+readers not to simplify it.
+
+Two things follow. First, the flat-sibling and exhaustive-`match` rules must not be
+pointed at this file; they describe closed unions the project owns, and this file
+dispatches an open hierarchy it does not. Second — and this is the part that would
+otherwise be missed — the handler contains **zero `except` blocks**, because it is
+invoked by registration. Every gate that finds error handling by matching `except`
+is blind to the single most important error-handling file in the repository, and per
+D14 must say so rather than report a clean sweep.
+
+### D18 — a family with no catch site is a defect; re-rooting beats widening
+
+Of the six exception families under `connections/` and `shared/` rooted outside the
+project base, **five are caught nowhere at all**:
+
+| Family | Root | Raises | Catches |
+|---|---|---|---|
+| `TransientExternalError` | `Exception` | 2 | 4, by name |
+| `CircuitBreakerOpenError` | `RuntimeError` | 2 | 0 |
+| `IdempotencyLockError` | `RuntimeError` | 1 | 0 |
+| `AgentMemoryError` +3 | `RuntimeError` | 2 | 0 |
+| `CogneeSetupError` +1 | `RuntimeError` | 2 | 0 |
+| `StateSchemaVersionError` | `ValueError` | 1 | 0 |
+
+`TransientExternalError` is the shape to copy — declared at the retry boundary,
+caught by name at each consuming node. The other five propagate to whichever generic
+boundary happens to sit above them: the global handler's unhandled-500 branch on a
+request path, `server_middleware.py`'s one bare `except Exception`, or nothing at all
+in a Celery worker, whose outbox relay names only `CeleryError` and `PostgresError`.
+
+`connections/celery_registry.py` shows the second correct resolution, and it is the
+one that keeps the rule from over-firing. `TaskDispatchError` is rooted at
+`CeleryError` and never raised directly; `UnregisteredTaskError` and
+`TaskPayloadValidationError` are raised twice each and caught by name nowhere. A rule
+that flags "family with no catch clause naming it" would report all three. It should
+report none: the relay's `except (CeleryError, PostgresError)` reaches them through
+their root, which is exactly the re-rooting outcome this decision prefers. Reachability
+is therefore defined over ancestors, not over exact names — and an abstract base with
+zero raise sites is a base, not dead code.
+
+| Alternative | Why not |
+|---|---|
+| Widen a dispatcher to `except Exception` | Cannot distinguish an optional subsystem being absent from a required one being misconfigured; this is why `lifespan.py`'s 14 named handlers are the reference and its single catch-all is the exception |
+| Root everything at `APIException` | A circuit-breaker trip inside a Celery worker has no HTTP response to render; the base would imply a transport that is not there |
+| Leave them uncaught and rely on the generic 500 | The 500 is what happens today, and it is why a tripped breaker is indistinguishable from a null dereference in the logs |
+| **Re-root to a base the path's dispatcher already catches; widen by name only where re-rooting would lie about the transport** | Keeps dispatch declarative, and `lifespan.py`'s `except CogneeDimensionMismatchError` shows the by-name form working where re-rooting a startup-only family would add nothing |
+
+The audit obligation is stated as a requirement rather than a task because the same
+gap reappears every time a new subsystem is added: declaring an exception is
+satisfying, and wiring the catch is a separate act nobody is prompted to perform.
+
+### D19 — the spine extends `shared/result/`; the old hierarchy is its predecessor, not its rival
+
+Earlier drafts of this design said `app/shared/errors/` "is introduced". That was
+written without opening `src/app/shared/result/`, which already contains `errors.py`
+(`AppError` plus five subclasses), `types.py` (`AppResult`), `mappers.py` (the
+exception bridge) and `logging.py` (the failure logger). Introducing a second
+vocabulary package would have created two homes for one concept during the exact
+window in which the first is being retired — and `result-layer-boundaries` already
+classifies `shared/result/errors.py` as *the* vocabulary layer, so the two specs
+would have contradicted each other on where `ErrorKind` lives.
+
+`ErrorKind` and `FeatureError` therefore land in `app/shared/result/`. What the
+existing hierarchy turns out to be is more interesting than the path:
+
+```python
+class ValidationAppError(AppError):
+    kind: Literal["validation"] = "validation"
+    code: str = ErrorCode.VALIDATION_ERROR
+```
+
+Five subclasses, each with a `kind` `Literal` field — `validation`, `not_found`,
+`conflict`, `infrastructure`, `external_service`. **Exactly the five kinds scoping
+proposed.** The five-member vocabulary was not an arbitrary starting point; it was
+this hierarchy, read back. That also explains why `AUTHENTICATION` and
+`AUTHORIZATION` were missing from it (D4/ADR-003): they are missing from the code
+too, which is why `auth`'s 16 `UnauthorizedException` raises have no home in the
+`AppError` world and route around it entirely.
+
+So the change is narrower than "introduce a vocabulary" and sharper than "add two
+members". It is three edits to a shape that already exists:
+
+| Existing | Becomes | Why |
+|---|---|---|
+| `kind: Literal[...]` on 5 subclasses | `kind: ClassVar[ErrorKind]` on flat siblings | a field is settable per-instance and invites a sixth subclass; a `ClassVar` is not constructible at all |
+| `code: str = ErrorCode.X` | `code: ClassVar[<Owner>Code]` | the annotation is `str`, which is precisely why 118 off-enum literals type-check today |
+| 5 kinds | 7 kinds | 401 and 403 have no expression, so a failed login renders 422 |
+
+Two consequences worth carrying into the tasks. First, the migration surface is
+**123 construction sites**, not the 5 class definitions: `InfrastructureAppError` ×72,
+`NotFoundAppError` ×21, `ConflictAppError` ×15, `ValidationAppError` ×10,
+`ExternalServiceAppError` ×2, bare `AppError` ×3. They retire per feature, which is
+what makes the 16 feature changes the bulk of this work rather than the foundation.
+
+Second, `AppError` **has no `kind` field** — only its subclasses do. A bare instance
+therefore raises `AttributeError` on `.kind`, and one exists:
+`features/ingestion/service.py:86` constructs `AppError(code="UNKNOWN",
+message=str(failure))`. Today that is harmless because nothing dispatches on `kind`
+anywhere in the codebase — the field is declared and never read. The renderer will be
+its first consumer, so the kindless instance has to go before `render_result` can meet
+it, not after.
+
+That bare instance is also a live misclassification, independent of this design.
+`mappers.py`'s `case AppError():` arm sits last, correctly ordered narrowest-first, and
+maps the base to `ValidationException` — **422**. So an internal failure labelled
+`"UNKNOWN"` is currently reported to the client as a validation error, which tells the
+caller to fix their input for a fault that is not theirs. It corrects to 500 under
+`STATUS_BY_KIND`.
+
+The same mapper is the codebase's own demonstration of D2's argument: because its
+`match` ends in a concrete-base arm rather than a closed union, `assert_never` cannot
+be used there, and no type checker can tell whether its six arms are complete.
+
+### D20 — the exemption is the unit of work in the five later-added directories
+
+`app/api/`, `app/config/`, `app/examples/`, `src/database/` and `src/tasks/` were added
+to scope after the first three review passes. Together they are 22 `.py` files, 12
+raises and 47 `except` clauses — under a tenth of the infrastructure surface D15–D18
+cover. The interesting property is not their size but their **kind**: almost nothing in
+them converts to `Result`. What they need is the opposite — a written statement of what
+is *exempt*, and from what.
+
+| Construct | Sites | Disposition | Why |
+|---|---|---|---|
+| Pydantic validator `ValueError` | `config/settings.py:473`, `api/strict_envelope.py:26` | exempt, never convert | `ValueError` *is* Pydantic's signalling protocol; a `Result` there validates successfully |
+| PEP 562 module `__getattr__` `AttributeError` | `src/database/__init__.py:37` | exempt, never convert | `hasattr` and `from … import` depend on the raise |
+| `NotImplementedError` stub | `tasks/pageindex_tasks.py:30` | exempt | an unwritten function, not error handling |
+| Version-router aggregation | `api/v1.py`, `api/v2.py` | no rule | constructs, catches, propagates and renders nothing |
+| ORM declaration | `database/base.py`, `database/schemas/*` | no rule | same |
+| Broad catch **with** a written reason | 55 of 62 repo-wide `# noqa: BLE001` | endorsed form | already the convention; `lifespan.py:234` is the reference |
+| Broad catch with a bare suppression | 7 — `subscriptions/service.py` ×4, `billing_tasks.py` ×3 | violation | worse than no suppression: silences the rule that asks *why* and answers nothing |
+| Blind `except` ending in `raise` | `middleware/server_middleware.py:100` | no rule, no reason owed | nothing was survived; `BLE001` itself spares this shape |
+| `except Exception` → relabel as unavailable | `api/generation_with_cb.py:33,36` | convert | a breaker that trips on the project's own `TypeError` makes its own metric unreadable |
+| Seeder-loop catch | `database/seeders/run_seeders.py:81` | keep the catch, fix the exit status | a silently-failing seeder produces a database that looks seeded |
+
+**The distinguishing test for the first three rows is who reads the raise, not what is
+raised.** A `ValueError` inside a validator is read by Pydantic; a `ValueError` in a
+service is read by project code and converts like any other. Typing the exemption to
+the exception class would be wrong and would exempt the wrong sites.
+
+**`app/examples/` is the one that changes how the gates are read.** Its violation is
+not four bad lines; it is that `pyproject.toml`'s `per-file-ignores` disables
+`BLE001`, `E722`, `B904`, `TRY201`, `TRY300`, `TRY301`, `TRY400` and `S112` for
+`src/app/examples/*.py` — eight of the rules this change is about — with a second,
+narrower block for `rag_agent_advanced.py` whose `BLE001` is already dead (that file
+has no blind `except`). So `ruff check src/app/examples/` says *"All checks passed!"*
+while `ast-grep scan` reports **4 `error`-level `no-raw-httpexception` violations** in
+`redis_examples.py`. ast-grep is the only gate still reporting because it is the only
+one with no per-path ignore configured.
+
+This is **ADR-005 in a second form.** The first was a rule whose pattern matched a form
+nobody writes; this is a working rule pointed away from the code. Both produce the same
+artefact — a zero count that reads as coverage — from opposite causes. So ADR-005's
+obligation extends: verifying a gate means checking what it was configured to skip, not
+only that its pattern fires. The 8 entries are removed here, and the findings that
+surface are fixed rather than re-suppressed.
+
+Two consequences worth carrying forward. The 8 `except DatabaseException` catches in
+`redis_examples.py` must move in the **same** change that reclassifies
+`utils/cache/redis_func.py`, since this file is one of that module's only two importers
+— split across two changes, the example would catch an exception nothing raises and
+stop handling anything without failing. And 4 of the 7 reasonless `# noqa: BLE001`
+sites are in `features/subscriptions/service.py`, the exemplar this change migrates, so
+they close under section 5 whether or not the degradation rule exists.
+
+## Risks / Trade-offs
+
+- **Rewriting `no-match-on-result` could mask a real violation.** Its pattern is
+  `regex: ^(Success|Failure)\(\s*\)$` on a `case_pattern` — it fires only on the
+  argument-less form. The bound form the deployed spec mandates is invisible to
+  it. → The rewrite is verified against a fixture containing both forms before it
+  is trusted, and the "zero match-on-Result" count is re-measured with the new
+  rule rather than carried over.
+- **17 small enums invite copy-paste divergence.** → `ErrorKind` carries every
+  cross-feature decision; the code enums are only for identity in the envelope.
+- **`extra="forbid"` turns a stale keyword into a runtime `ValidationError`.**
+  A call site left passing `code=` fails at construction, inside an `except`
+  block, where it can mask the original error. → Migration is per feature and
+  gated by `ty`, which sees the unknown keyword statically; the runtime failure
+  is the second line of defence, not the first.
+- **The rollback fix changes behaviour where a failure is currently swallowed.**
+  → The 21 `webhooks` unwraps are the first place to look for tests that encoded
+  the old behaviour.
+- **`test_error_envelope_is_universal.py` asserts over 31 exception names, 12
+  `ErrorCode`s and 8 envelopes.** → It is updated in this change, not deferred;
+  it is the closest thing the repo has to a contract test for the envelope.
+- **Two features cannot be verified end to end.** `crawler` and `ingestion`
+  routers are mounted in neither `api/v1.py` nor `api/v2.py`. → Their changes
+  note it; mounting is out of scope.
+- **`utils/cache/redis_func.py` is reachable from no request path.** Its only
+  importers are `utils/cache/__init__.py` and `examples/redis_examples.py`, so its 27
+  `DatabaseException` raises for Redis failures are a latent misclassification rather
+  than a live 500. → Scheduled with the foundation anyway, because it is the
+  documented cache pattern and its 4 `no-raw-httpexception` violations live in its
+  only caller; but the risk register should not carry it as a production fault.
+- **The ten non-feature directories widen the foundation change.** Naming them
+  by role rather than converting them keeps the added work bounded, but `shared/` is
+  111 files and a later reader could read "in scope" as a mandate. → Scope is stated
+  per subtree in the proposal's table, and D15's rule is "whoever classifies a
+  third-party exception", which excludes the graph nodes and LLM plumbing by
+  construction rather than by exception. The five added in the fourth pass are
+  covered by D20, which states them as exemptions rather than conversions.
+- **A passing gate may have been configured to skip the code.** Eight error-handling
+  ruff rules are disabled for `src/app/examples/*.py`, so that directory's clean lint
+  run has never been evidence. → D20 removes the entries; ADR-005's verification
+  obligation is read to include auditing a gate's exclusions, not only its pattern.
+
+## Migration Plan
+
+**17 changes total: this foundation, then 16 features.** 18 features exist. The
+arithmetic differs from the 18 changes estimated when scope was agreed for two
+reasons: `subscriptions` migrates inside this change as the exemplar rather than
+getting its own, and `chat` needs no change at all — it is `__init__.py` and
+`model.py`, with zero raises and zero `except` clauses.
+
+**Phase 1 — this change.** Shared spine (`app/shared/result/` extended in place, the
+renderer, `mappers.py`, the global handler); rollback added to all 9 relational
+repositories' 74 SQLAlchemy handlers; the doc surfaces reconciled; the gates written
+and verified against fixtures; `subscriptions` migrated end to end.
+
+Also in Phase 1, from the infrastructure scope: the six unrooted families re-rooted
+or named and reachability defined over ancestors (D18); the session dependency's shape
+pinned by requirement, with no code change (D16); the dispatcher's exemption written
+into the gates so no new rule flags it (D17).
+
+And from the five directories added in the fourth pass (D20): the three
+framework-contract raises exempted by name so no gate fires on them; the eight
+error-handling entries removed from `per-file-ignores` for `src/app/examples/*.py` and
+the findings that surface fixed, including the 4 live `no-raw-httpexception`
+violations; `generation_with_cb.py`'s broad-catch relabel replaced with named provider
+classification; the seeder loop's exit status corrected; and the 7 reasonless
+`# noqa: BLE001` sites given a reason — 4 of which are in `subscriptions/service.py`
+and close under the exemplar work regardless.
+
+**`utils/cache/` lands here, not deferred.** Task 7.5 reclassifies its 27
+`DatabaseException` raises, and `examples/redis_examples.py`'s 8
+`except DatabaseException` catches move in the same change because that file is one of
+the module's only two importers — split apart, the example would catch an exception
+nothing raises and stop handling anything without failing. An earlier draft of this
+plan listed the pair as deferred while the risk register and `tasks.md` both scheduled
+it; the schedule is correct and the deferral line was stale.
+
+**Phase 1a — `shared/services/`, immediately after the foundation and before any
+feature.** This is an ordering constraint, not a preference. A feature that migrates
+while its shared dependency still raises `APIException` must `try`/`except` around a
+call the project owns — precisely what `result-layer-boundaries` forbids — so the
+wrapper has to be Result-typed before the first feature that consumes it.
+
+The 31 raises are not spread evenly, and which module blocks which feature decides
+the ordering:
+
+| module | raises | catches | earliest consuming feature |
+|---|---|---|---|
+| `tavily.py` | 8 | 3 | **`crawler` (3rd)**, via `search` re-exported from the package `__init__` |
+| `storage.py` | 21 | 15 | `profile` (7th), then `invoices` (9th), `documents` (15th); also `lifecycle/lifespan.py` |
+| `mailer.py` | 2 | 2 | none — no importer outside `shared/services/` |
+| `rate_limiter.py` | **0** | **0** | `crawler` (3rd), but nothing to convert |
+
+`tavily.py` is what makes Phase 1a urgent, not `rate_limiter.py`. `rate_limiter.py`
+raises nothing and catches nothing — `check_rate_limit` returns
+`tuple[bool, dict[str, Any]]`, and the 429 is raised by `crawler/router.py` from that
+boolean. There is no `APIException` for a consuming feature to wrap, so converting it
+is a no-op for this contract and it is excluded from the conversion.
+`result-layer-boundaries` classifies that guard so no gate fires on it.
+
+Two shapes inside Phase 1a are worth naming before the work starts. Four of
+`tavily.py`'s 8 raises (lines 58–64) are pre-flight argument guards — missing API key,
+empty query, non-positive `max_results`, unknown `topic` — not classifications of a
+third-party failure; a missing API key is a configuration fault and the other three
+are caller-contract violations. Only its 4 `ExternalServiceException` raises are
+genuine boundary classification. `storage.py` is the opposite and simpler: 17 of its
+21 raises are `ServiceUnavailableException`, which maps to `INFRASTRUCTURE` with
+`retryable=True` and renders 503 — the same status it produces today, so its
+conversion has no observable break.
+
+Three modules with 31 raises still makes this the smallest conversion in the
+repository, which also makes it the second exemplar after `subscriptions`.
+
+Deferred to their own changes: `shared/crawler/` alongside the `crawler` feature; and
+`shared/rag/`'s provider boundary alongside `documents`, whose ingestion path consumes
+it. `utils/cache/` is **not** among them — see Phase 1 above.
+
+Rollback for all 9 relational repositories lands here rather than per feature, because it
+is a correctness fix with no dependency on the error redesign, and leaving it
+staged across 17 changes leaves poisoned-commit paths open for the duration.
+
+**Phase 2 — 16 features, in ascending difficulty:**
+
+`search` → `audit` → `crawler` → `users` → `ingestion` → `dunning` → `profile` →
+`plans` → `invoices` → `payments` → `webhooks` → `agent_saul` → `health` →
+`credits` → `documents` → `auth`
+
+Difficulty here means error-site count, unwrap-site count, and how many
+exception-native boundaries the feature touches. `search` is first because it is
+small enough that a mistake in the exemplar surfaces cheaply. `auth` is last
+because it is the security boundary and its dependencies are the one place
+raising is structurally required. `plans` is early relative to its size because
+it is the only repository already using the enum, so it is the least changed.
+
+**Per-feature exit criteria** — all must hold before the change is archived:
+
+1. `errors.py` exists; every repository and service method returns
+   `<Feature>Result[T]`.
+2. The feature's old exception classes are deleted; no call site remains.
+3. Its chains are flattened; no concrete type inherits a concrete type.
+4. Its endpoints render through `render_result`; no endpoint raises for an
+   expected failure.
+5. Its database handlers roll back.
+6. `ruff` clean, `ty` no new errors, `ast-grep` no new violations, its tests pass.
+7. No `# noqa` or `# ty: ignore` added to reach 6.
+
+**Rollback strategy.** Per feature, a revert is a single-change revert: the
+feature's `errors.py` and its call sites move together, and no other feature
+imports them — that is what D3's no-cross-feature-import rule buys operationally.
+The foundation change is the exception: reverting it after features have migrated
+would strand them, so it is the one change that must be rolled forward, not back.
+
+**Observable break.** `"DB_ERROR"` → the enum's `DATABASE_ERROR` at 56 sites,
+with the status correcting 503 → 500. This lands in the foundation change, in one
+step, rather than drifting across 17 releases.
+
+## Open Questions
+
+- Whether `docs-site/architecture/error-and-result-pattern.mdx` should document
+  the per-feature union in full or link to `.opencode/instructions/`. Answerable
+  when the rewritten instruction docs exist; it changes no spec, no interface,
+  and no task beyond the wording of one doc task.

--- a/openspec/changes/error-handling-foundation/proposal.md
+++ b/openspec/changes/error-handling-foundation/proposal.md
@@ -1,0 +1,362 @@
+> Change class: **L** — cross-cutting (18 features, shared spine, security boundary, public error envelope, enforcement gates)
+
+## Why
+
+`AppError` is an open hierarchy. Because anyone can subclass it anywhere, no type
+checker can enumerate its subclasses, so no `match` over it can ever be proven
+exhaustive. Every downstream weakness follows from that one property:
+
+- **56 sites** across 9 repositories construct `InfrastructureAppError(code="DB_ERROR")`.
+  `"DB_ERROR"` matches no `ErrorCode` member — the enum spells it `DATABASE_ERROR`.
+  `plans/repository.py` is the only repository that uses the enum, in structurally
+  identical `except SQLAlchemyError` blocks. The literal survives to the client:
+  `mappers.py` forwards `error_code=error.code` and the handler emits it verbatim.
+  Because `InfrastructureAppError` defaults `retryable=True`, these map to **503,
+  not 500** — clients are told to retry a transaction that is already dead. For **49
+  of the 56** that is the correction to make. The other **7 are in
+  `auth/repository.py`, which is MongoDB and Redis, not SQLAlchemy** — those are
+  genuinely retryable and must keep 503. One string was hiding two different failure
+  modes.
+- **118 off-enum code literals** emit **68 distinct codes** against an 18-member
+  enum. `code` is a Pydantic field with a default, so every construction site can
+  invent or mistype one. The drift is not an accident; it is the only thing the
+  type is shaped to allow.
+- **Zero repositories roll back.** Of 11 repository modules, **9 are relational** and
+  carry 74 SQLAlchemy handlers between them; every one returns `Failure` and leaves
+  the session in a failed transaction. (`auth` is a document store; `users` catches
+  nothing.) Where a service swallows that `Failure` instead of raising —
+  `webhooks/service.py` (21 unwraps, zero bridge calls), `dunning/service.py` — no
+  exception escapes, so `get_postgres_db`'s `except` never fires and
+  `await session.commit()` runs against a poisoned session. `session.rollback` has
+  never existed under `src/app/features/` in the entire history of the repository.
+- **28 concrete-inherits-concrete chains** already exist (19 under `APIException`,
+  9 outside it). `match`'s class patterns are `isinstance`-based, so a broader arm
+  placed before a narrower one silently makes the narrower arm dead — and a type
+  checker still reports the match exhaustive, because from its view every case was
+  covered. It has no concept of *reached but shadowed*. This is invisible
+  statically and at runtime; it shows up only as the wrong branch's side effects.
+- **Five of six unrooted exception families are caught nowhere.** Under
+  `connections/` and `shared/`, six families are rooted at `RuntimeError`, bare
+  `Exception` or `ValueError`. `CircuitBreakerOpenError`, `IdempotencyLockError`,
+  `AgentMemoryError`, `CogneeSetupError` and `StateSchemaVersionError` all have raise
+  sites and **zero catch sites** anywhere in the repository; only
+  `TransientExternalError` is caught by name. The contrast that shows the fix:
+  `celery_registry.py`'s `TaskDispatchError` family is rooted at `CeleryError`, so the
+  outbox relay's existing catch reaches its two subclasses without any clause naming
+  them.
+- **The infrastructure directories were the plan's blind spot.**
+  `src/app/shared/services/` is four third-party wrappers (boto3, httpx) with 31
+  raises of `APIException` subclasses, 20 catches every one of a library type, and
+  no `Result` at all — the exact shape this work converts, invisible to a rule
+  scoped to `features/`. It is not peripheral: `storage` is imported by `profile`,
+  `invoices` and `documents`, and `rate_limiter` by `crawler`.
+  `utils/cache/redis_func.py` raises `DatabaseException` at 27 sites for **Redis**
+  failures, so a cache outage would render as a non-retryable `DATABASE_ERROR` 500 —
+  latent rather than live, since its only importers are its own `__init__` and
+  `examples/redis_examples.py`.
+- **One directory is exempted from the error-handling lint rules in writing, and it
+  is the one that gets copied.** `pyproject.toml`'s `per-file-ignores` disables
+  `BLE001`, `E722`, `B904`, `TRY201`, `TRY300`, `TRY301`, `TRY400` and `S112` for
+  `src/app/examples/*.py`. That is why `ruff check src/app/examples/` reports "All
+  checks passed!" while `ast-grep scan` — which has no per-path ignore — reports **4
+  `error`-level `no-raw-httpexception` violations** in `redis_examples.py`. A green
+  lint run over that path has never been evidence about the code.
+
+A feature-local closed union fixes this at the type-system level rather than by
+convention. Measured on this repository with the project's own `ty`:
+
+| Construct | `ty` verdict |
+|---|---|
+| `match result: case Success(value)` | **no narrowing** — binds `int \| DupErr \| MissingErr` |
+| `isinstance(result, Failure)` then `.failure()` | narrows to `DupErr \| MissingErr` |
+| `match error:` over closed union + `assert_never` | passes |
+| same, one arm removed | `error[type-assertion-failure]: Inferred type is MissingErr & ~DupErr` |
+
+Exhaustiveness is real, but it belongs on the **error union**, not on the
+`Result` container. That distinction is what makes this change compatible with
+the existing `no-match-on-result` gate instead of in conflict with it.
+
+## What Changes
+
+- **BREAKING** — `app/shared/result/` gains `ErrorKind` (7 members),
+  the `FeatureError` Pydantic base with `kind`/`code`/`retryable` as `ClassVar`,
+  and `STATUS_BY_KIND`. `code` and `kind` stop being constructor parameters, so
+  a mistyped code becomes unconstructible rather than merely discouraged.
+  This extends the package that already owns the shared error vocabulary rather
+  than adding a second one: `shared/result/errors.py` holds `AppError` and five
+  subclasses that already carry `kind` as a `Literal` field, with the same five
+  values, across 123 construction sites. The migration moves `kind` from a
+  per-subclass field to a `ClassVar` on flat siblings and adds the two members the
+  old hierarchy could not express — it does not introduce the concept.
+  `ErrorKind` carries two members beyond the five agreed at scoping —
+  `AUTHENTICATION` (401) and `AUTHORIZATION` (403) — because `auth/service.py`
+  raises `UnauthorizedException` at 16 sites and the locked scope converts that
+  service to Result-typed. Five members cannot express 401 or 403, so a failed
+  login would render 422. See `design.md` D4.
+- **BREAKING** — every feature gains `features/<name>/errors.py` declaring its own
+  `<Feature>Code` StrEnum, its flat sibling error types, a closed
+  `type <Feature>Error = A | B | C` union, and `type <Feature>Result[T]`.
+  No feature imports another feature's error types or codes.
+- **BREAKING** — repositories roll back inside the `except` block before returning
+  `Failure`. This closes the poisoned-commit path and is the precondition for
+  services no longer needing to raise.
+- Routers render a `Result` through one shared `render_result(...)` that emits the
+  `http_error` envelope **and** sets the real HTTP status from
+  `STATUS_BY_KIND[error.kind]`. Today `http_error` writes the status into the body
+  only, so returning it from a route yields HTTP 200 with `"success": false`.
+- Every layer that is exception-native in its own right is **named** and given a
+  written adapter contract plus an enforcement rule — WebSocket sessions, Celery
+  tasks, both tenacity boundaries, FastAPI auth dependencies, LangGraph nodes,
+  MCP handlers, the circuit breaker, SSE streaming, beat cron, scripts, alembic.
+  These are not converted; they are classified, so no file is left undefined.
+- The ten non-feature directories — `connections/`, `lifecycle/`,
+  `middleware/`, `shared/`, `utils/`, `app/api/`, `app/config/`, `app/examples/`,
+  `src/database/` and `src/tasks/` — are brought into the contract by role rather
+  than by directory. Shared third-party wrappers own unions and return Results; the
+  cache layer stops reporting Redis failures as database failures; the session
+  dependency is pinned to its current shape and forbidden from inspecting Results;
+  the global exception handler's `isinstance` dispatch over framework types is
+  explicitly exempted from the union rules and its split registration protected; the
+  lifespan's named-family degradation is made the reference for widening a
+  dispatcher; every family caught nowhere is either re-rooted or named; a raise that
+  satisfies a framework contract is exempted by name rather than by accident; a
+  deliberate degradation in a task body must state why the failure is survivable; and
+  the example directory loses the exemption it has been holding by habit — it
+  currently carries **4 live `error`-level violations of the project's own
+  `no-raw-httpexception` rule**, in code whose purpose is to be copied.
+- `.opencode/instructions/EXCEPTION-RULES.md` and `RESULT-PATTERN.md` are
+  rewritten, and the drifted `.kiro/steering/` copies plus the public
+  `docs-site/` page are brought into lockstep. The four doc surfaces currently
+  teach three different rules; after this change they teach one.
+- The governance contradiction is resolved. `openspec/config.yaml`,
+  the `spec-gated` review instruction, and the `no-match-on-result` gate say
+  `isinstance`; the deployed `pattern-matching-standard` spec says `match`/`case`
+  SHALL be used and `isinstance` SHALL NOT; `.kiro/` says `isinstance` then
+  `raise`, which a third gate already calls retired. The code follows
+  `isinstance` + `http_error` (122 unwrap sites; **zero** match-on-Result). The
+  spec and the `.kiro/` copies are the stale artifacts and are corrected here.
+- `subscriptions` is migrated end to end in this change as the executable
+  exemplar every per-feature change is measured against.
+
+## Scope / Non-Goals
+
+**In scope:** the shared spine (`app/shared/result/`, `mappers.py`,
+`utils/exceptions.py`, `utils/codes.py`, the global exception handler), the
+repository rollback fix, the router renderer, the boundary classification and its
+gates, the instruction docs and all their copies, and the `subscriptions`
+feature as exemplar.
+
+Also in scope, by role rather than by directory — the ten non-feature trees:
+
+| Directory | What this change does to it |
+|---|---|
+| `connections/` | pins `get_postgres_db`'s shape as the rollback counterparty; re-roots or names `CircuitBreakerOpenError` and `IdempotencyLockError`; resolves the never-raised `TaskDispatchError` family |
+| `lifecycle/` | codifies `lifespan.py`'s named-family degradation as the reference pattern; no rewrite |
+| `middleware/` | exempts the global handler's `isinstance` dispatch from the union rules and protects its split registration; classifies the health probes and `server_middleware`'s catch-all |
+| `shared/` | `shared/services/` (4 modules, 31 raises) becomes Result-typed with per-module unions, and must land **before `crawler`**, its first consuming feature; `shared/crawler/` follows the same shape at 9 sites; `shared/rag/` converts only its `_provider_failure` boundary — its 7 `ImportError` guards are capability detection, not error handling; the `RuntimeError`-rooted memory and cognee families are re-rooted or named |
+| `utils/` | `exceptions.py` and `codes.py` are frozen as vocabulary; `cache/redis_func.py`'s 27 `DatabaseException` raises are reclassified as cache failures, with `examples/redis_examples.py` corrected alongside |
+| `app/api/` | `generation_with_cb.py`'s `except Exception` → `ServiceUnavailableException` relabel is replaced by named provider classification, so the circuit breaker stops counting the project's own defects as upstream outages; `strict_envelope.py`'s validator `ValueError` is exempted as a framework contract; `v1.py`/`v2.py` are recorded as handling nothing |
+| `app/config/` | `settings.py:473`'s validator `ValueError` is exempted as a framework contract and explicitly protected from conversion — a `Result` there would make an invalid field validate successfully |
+| `app/examples/` | the **8 error-handling rules ruff is told to ignore for this path** (`BLE001`, `E722`, `B904`, `TRY201`, `TRY300`, `TRY301`, `TRY400`, `S112`) are removed from `per-file-ignores`, which is why a green `ruff check` here has never been evidence; the 4 `raise HTTPException(status_code=500, …)` violations in `redis_examples.py` are corrected; its 8 `except DatabaseException` catches follow the cache reclassification in the same change; and `rag_agent_advanced.py`'s 9 named `(OpenAIError, GoogleAPIError)` handlers are confirmed as the endorsed form and left alone |
+| `src/database/` | `seeders/run_seeders.py:81`'s loop catch must name the failing seeder and report a failing exit status; `__init__.py:37`'s PEP 562 `AttributeError` is exempted as a framework contract; `base.py` and `schemas/` handle nothing |
+| `src/tasks/` | the reason-carrying `# noqa: BLE001` form becomes the written rule, since **55 of the repo's 62 such sites already use it**; the 3 bare suppressions in `billing_tasks.py` and the 12 unsuppressed broad catches must name their families or their reason; `pageindex_tasks.py:30`'s `NotImplementedError` stub is excluded; the near-identical `auth_email_tasks.py` / `auth_email_tasks_typed.py` pair is reconciled to one |
+
+**Out of scope — deliberately:**
+
+- The other 16 features. Each gets its own change, ordered by the roadmap in
+  `design.md`. Their old exception classes die in the same change that replaces
+  their last call site; no feature carries a dual system. (18 features exist;
+  `subscriptions` migrates here as the exemplar, and `chat` is two files —
+  `__init__.py` and `model.py` — with zero raises and zero `except` clauses, so it
+  needs no change at all.)
+- `src/mcp_core/` — 19 modules, 23 raises, 10 `except` clauses. Excluded by the
+  owner's decision, not by oversight. `result-layer-boundaries` records the
+  exclusion so a later reviewer does not report it as a coverage gap; the layer
+  table's "MCP tool handlers and middleware" row classifies the *pattern* without
+  scheduling the directory.
+- Converting any exception-native layer to Result. Those layers get a contract
+  and a gate, not a rewrite.
+- Rewriting `lifecycle/lifespan.py` or the global exception handler. Both are
+  measured to be doing the right thing; this change makes their behaviour a rule so
+  it cannot be "simplified" away, and changes no code in them.
+- The `shared/langchain_layer/` and `shared/langgraph_layer/` node bodies beyond
+  re-rooting their families. Those are exception-native or state-carrying layers and
+  are classified, not converted.
+- The 2 pre-existing `ty` errors (`app.shared.langchain_layer.agents.memory.setup_types`
+  unresolved) and the 2 pytest collection errors they cause. They predate this
+  work and are owned by no requirement here.
+- The 12 known websocket fixture-drift test failures.
+- `src/lynk/` — a separate Go project: 24 `.go` files and **zero** `.py`, so it is
+  outside this contract by nature rather than by decision. And `src/alembic/`
+  migration bodies.
+
+## Capabilities
+
+### New Capabilities
+
+- `feature-error-contract`: the `FeatureError` base, `ErrorKind`, the per-feature
+  `<Feature>Code` StrEnum, the closed-union and flat-sibling rules, the freeze on
+  the `AppError` hierarchy for the migration's duration, and the exhaustiveness
+  obligation that makes them checkable.
+- `result-layer-boundaries`: which layers are Result-typed, which are
+  exception-native, and the adapter contract each exception-native layer owes at
+  the point it hands off to domain code — including the `try`/`except` rule, the
+  construction-site logging rule, and the obligation that every enforcement gate
+  be verified against both a permitted and a forbidden construct before its counts
+  are trusted.
+- `repository-transaction-safety`: a repository that catches a database exception
+  rolls back before returning `Failure`, so a swallowed failure can never reach
+  `commit()`.
+- `http-result-rendering`: routers render a `Result` into the `APIResponse`
+  envelope with the correct HTTP status derived from `ErrorKind`.
+- `shared-infrastructure-errors`: the rules for the ten directories that are not
+  features but carry the machinery every feature's errors travel through — the
+  shared third-party wrappers that own unions, the cache layer's classification, the
+  session dependency's fixed shape, the global dispatcher's exemption, the startup
+  degradation boundary, the obligation that a family rooted outside the project
+  base be caught by name or re-rooted, the exemption for a raise a framework
+  contract requires, the obligation that a deliberate degradation name its reason,
+  the seeder's exit status, the circuit-breaker adapter's named classification, and
+  the rule that example code holds no lint exemption of its own.
+
+### Modified Capabilities
+
+- `pattern-matching-standard`: the requirement mandating `match`/`case` on
+  `Success`/`Failure` is inverted to match measured `ty` behaviour —
+  `isinstance` opens the `Result`, `match` is reserved for the closed error
+  union where it actually narrows and where `assert_never` has meaning.
+- `typed-exception-handling`: the agent-tools requirement names
+  `ToolOutput.fail()`, which was deleted in `5994dd8`. Its scenarios are
+  restated against the surviving `ToolResult`, and the third-party catch
+  taxonomy is reconciled with the new adapter contract.
+
+## Impact
+
+- **Code, this change:** `app/shared/result/` (`errors.py`, `types.py`,
+  `mappers.py`, `logging.py` — extended, not replaced), `utils/exceptions.py`,
+  `utils/codes.py`, `utils/http_response.py`,
+  `middleware/global_exception_handler.py`,
+  `features/subscriptions/*`, and the 9 relational repositories' 74 SQLAlchemy
+  handlers for the rollback fix. The 123 existing `*AppError` construction sites
+  (72 of them `InfrastructureAppError`) are the migration surface for the
+  vocabulary change; they are retired per feature, not here.
+- **Code, downstream changes:** 63 files across the 18 features become
+  Result-typed; 152 files fall under a named rule.
+- **Infrastructure surface, newly in scope:** 148 files across the five original
+  directories (`connections/` 12, `lifecycle/` 3, `middleware/` 6, `shared/` 111,
+  `utils/` 16), carrying 115 raise sites and 228 `except` clauses. The dense spots are
+  `utils/cache/redis_func.py` (69 sites in one file), `shared/rag/` (70 across 23
+  files), `shared/services/` (51 across 4), and `lifecycle/lifespan.py` (14 handlers
+  naming ~20 distinct types against exactly one bare `except Exception`).
+- **The five later-added directories are small and dense in one place:**
+
+  | Directory | `.py` | raises | `except` | Where the work is |
+  |---|---|---|---|---|
+  | `app/api/` | 5 | 2 | 1 | the single `except Exception` → `ServiceUnavailableException` relabel in `generation_with_cb.py` |
+  | `app/config/` | 2 | 1 | 0 | one validator `ValueError`, exempted not converted |
+  | `app/examples/` | 4 | 7 | 28 | 25 of the 28 catches and all 4 gate violations are in `redis_examples.py`; the ruff ignore list is the real edit |
+  | `src/database/` | 7 | 1 | 1 | one seeder-loop catch; the rest is ORM declaration |
+  | `src/tasks/` | 10 | 1 | 17 | 15 of 17 catches owe a reason; 2 already carry one |
+
+  22 files, 12 raises, 47 `except` clauses in total — under a tenth of the
+  infrastructure surface above, and no new capability is needed to hold them.
+- **Error surface:** 431 error sites, 111 `AppError` constructions, 187
+  `APIException` raises, 122 `isinstance(result, Failure)` sites, 5 copies of
+  `_repo_failure`/`_repo_error` across 44 call sites.
+- **Public API:** error `code` values change wherever a hardcoded literal is
+  replaced by an enum member — most visibly `"DB_ERROR"` → `DATABASE_ERROR` at
+  56 sites, whose status also corrects from 503 to 500. **BREAKING** for any
+  client matching on those strings.
+- **Docs:** four surfaces carry the rule, and they currently disagree by
+  generation — `.opencode/instructions/{EXCEPTION-RULES,RESULT-PATTERN}.md`
+  (isinstance + `http_error`), `.kiro/steering/{EXCEPTION-RULES,RESULT-PATTERN}.md`
+  (isinstance + `raise app_error_to_exception` — one generation stale, and it
+  teaches the exact pattern `no-raise-app-error-mapper` flags), the public
+  `docs-site/architecture/error-and-result-pattern.mdx` (aligned with
+  `.opencode/`), and the deployed `pattern-matching-standard` spec (mandates
+  `match`, forbids `isinstance` — two generations off). Also
+  `openspec/config.yaml`'s context block, the `spec-gated` review instruction,
+  and `CLAUDE.md`'s "Key files" line, which points at
+  `src/app/shared/response_type.py` — a path that does not exist (the real module
+  is `src/app/utils/response_type.py`).
+- **Gates:** `no-match-on-result` is rewritten — its pattern matches only the
+  argument-less `case Success()` form, so the bound `case Success(value):` form
+  passes unflagged and its reported zero violations are not evidence of anything.
+  `no-raise-app-error-mapper` is kept and its 34 violations retire per feature.
+  New rules cover the closed-union, flat-sibling, `ClassVar`-classification,
+  repository-rollback, no-cross-feature-import and `AppError`-freeze rules, plus
+  one per classified boundary. Every rule, new or rewritten, must be shown to flag
+  what it forbids and spare what it permits before its counts are used.
+- **Lint configuration:** `pyproject.toml`'s `per-file-ignores` loses 8 entries from
+  `src/app/examples/*.py` (`BLE001`, `E722`, `B904`, `TRY201`, `TRY300`, `TRY301`,
+  `TRY400`, `S112`) and 1 from `src/app/examples/rag_agent_advanced.py` (`BLE001`,
+  already dead — that file has no blind `except`). Expect ruff to report findings in
+  that directory for the first time; they are fixed, not re-suppressed.
+- **Tests:** 33 of 68 test files assert on error types, codes, messages or
+  envelopes. `tests/unit/middleware/test_error_envelope_is_universal.py` (31
+  exception names, 12 `ErrorCode`s, 8 envelopes) is the hardest to keep green
+  and must be updated in this change, not deferred.
+- **Dependencies:** none new. `returns` and `pydantic` are already present.
+
+## Risks
+
+- **The status correction is observable.** `"DB_ERROR"`/503 → `DATABASE_ERROR`/500
+  changes what clients see at 56 sites. → Land it here, in one change, with the
+  before/after table in `design.md`, rather than letting it drift feature by
+  feature.
+- **The rollback fix changes behaviour where a failure is currently swallowed.**
+  A request that silently committed a partial write will now roll back. → This is
+  the bug being fixed, but it can surface as newly-failing tests that encoded the
+  old behaviour; the 21 `webhooks` unwraps are the place to look first.
+- **A closed union is only closed if nothing else subclasses the base.** A new
+  subclass added outside a feature's `errors.py` and omitted from the union
+  silently reopens the hierarchy and `assert_never` stops meaning anything. The
+  same hazard applies to the retired hierarchy from the other direction: over 17
+  changes, adding to `AppError` is locally reasonable in every unmigrated feature
+  and collectively makes it grow while it is supposed to be retiring.
+  → Two enforcement rules, not conventions: one closing each hierarchy.
+- **The design rests on gates, and one of the existing gates does not work.**
+  `no-match-on-result` reports zero violations because its pattern looks for a
+  form nobody writes, not because the codebase is clean. Since a closed union is
+  closed only because a rule says so, an unverified gate reads as coverage while
+  providing none. → Every gate is verified against a permitted and a forbidden
+  fixture before its counts are cited; this is a requirement, not a practice.
+- **`auth` is scheduled last and is where the design was weakest.** The
+  five-member `ErrorKind` could not express 401 or 403, which would have surfaced
+  16 changes in. → Found by measurement during review and fixed before any code;
+  `ErrorKind` ships with 7 members. Recorded here because the near-miss is the
+  argument for auditing the plan against the ground rather than the reverse.
+- **`ty` verifies exhaustiveness but not shadowing.** A broader arm before a
+  narrower one is undetectable statically. → The flat-sibling rule is gated, and
+  the 28 existing chains are flattened as their features migrate.
+- **Baseline is not green** (ty 2, ast-grep 4 errors + 34 warnings, pytest
+  400/439 with 2 collection errors). → `design.md` records the baseline so
+  reviewers can tell a regression from an inheritance.
+- **Two features are unreachable.** `crawler` and `ingestion` routers are mounted
+  in neither `api/v1.py` nor `api/v2.py`, so their 4 endpoints cannot be verified
+  end to end. → Their changes note it; mounting them is not in scope here.
+- **The infrastructure scope was found by the author of the request, not by the
+  plan** — twice. A classification keyed on `features/` looked complete while missing
+  four third-party wrappers that are structurally identical to a repository, the
+  dispatcher every error passes through, and the session dependency the rollback
+  requirement exists to protect. Then a scope keyed on `src/app/{features,connections,
+  lifecycle,middleware,shared,utils}` looked complete while missing five more trees,
+  one of which holds live gate violations. → The classification is now keyed on
+  *role*, and `result-layer-boundaries` carries a scenario stating that not living
+  under `features/` is not grounds for exemption, plus one naming the two trees that
+  *are* excluded so their absence is a recorded decision rather than an implied
+  omission. The general lesson is recorded because a directory-shaped assumption hid
+  live error-handling code twice in the same change.
+- **A suppression list can make a gate report success.** `ruff check
+  src/app/examples/` passes today because 8 error-handling rules are disabled for that
+  path in `per-file-ignores`, while `ast-grep` — which has no per-path ignore — reports
+  4 errors in the same files. This is ADR-005's hazard in a second form: the first was
+  a rule whose pattern matched nothing, this is a working rule pointed away from the
+  code. → The 8 entries are removed in this change, and ADR-005's obligation is read
+  to include *checking what a passing gate was configured to skip*, not only whether
+  its pattern works.
+- **`shared/` is large and unevenly relevant.** 111 files, but the error density is
+  concentrated in four places and much of the rest is graph nodes and LLM plumbing
+  that is correctly exception-native. → Scope is stated per subtree in the table
+  above rather than as "all of `shared/`", so a later reader cannot read the
+  directory name as a mandate to convert the LangGraph layer.

--- a/openspec/changes/error-handling-foundation/review.md
+++ b/openspec/changes/error-handling-foundation/review.md
@@ -631,12 +631,31 @@ violates a dependency. The table was simply written before the history existed. 
 records what landed and splits only the remainder (A–E), which preserves the reviewable-
 unit goal without asking anyone to rewrite four commits.
 
-**28. Every planning artifact except `tasks.md` is untracked.** `proposal.md`,
-`design.md`, `adrs.md`, `review.md`, `specs/` and `HANDOFF.md` are all `??` in
-`git status`. `tasks.md` is tracked only because `0ca39ea` committed the section 1 ticks.
-So the branch currently carries 97 ticked-and-unticked checkboxes, four implementation
-commits, and no proposal, no ADRs and no spec deltas — a reviewer sees the answers with
-none of the reasoning, and `openspec archive` at the end would have nothing to fold.
+**28. The planning artifacts were untracked, were committed mid-session, and the commit
+captured a `tasks.md` that had lost section 9.** When this pass began, `proposal.md`,
+`design.md`, `adrs.md`, `review.md`, `specs/` and `HANDOFF.md` were all `??` in
+`git status` — only `tasks.md` was tracked, because `0ca39ea` had committed the section 1
+ticks. `853fe25 chore(openspec): add planning artifacts and no-match fixture for PR A`
+then committed the whole set, which resolves the original finding: the branch now carries
+its proposal, ADRs and spec deltas, and `openspec archive` has something to fold.
+
+What it did *not* resolve is worse, and is the reason this finding stays open. The
+`tasks.md` that `853fe25` committed is the **79-task, 10-section** version — the
+pre-fold-in state. Section 9 (the five later-added directories, 16 tasks), the
+renumbering of Verification to 10 and Handoff to 11, and tasks 10.7 and 11.5 were all
+absent from it. The specs kept every one of their 45 requirements and 180 scenarios, so
+the change still *specifies* the five directories while its task file no longer schedules
+any work against them. That is the exact failure mode the openspec archive hazard
+describes, arriving through a different door: a delta that validates while the plan
+behind it has been silently narrowed. Restored and re-committed; verify with
+`grep -n '^## ' tasks.md` that section 9 reads "The five later-added directories" and
+that the total is 97.
+
+The mechanism matters for anyone working this branch. Two workers were editing the change
+concurrently — one implementing, one planning — and `git status` is the only thing that
+distinguished "my edit is safe" from "my edit is the uncommitted side of a file someone
+else is about to commit from a stale tree." An untracked artifact survived; the tracked
+one was rewound.
 
 **29. Task 3.1's deferred re-measure is now done, and the answer is a real zero.** 3.1's
 own `DONE` block said "DONE (partial…) — full violation re-measure deferred". Completed

--- a/openspec/changes/error-handling-foundation/review.md
+++ b/openspec/changes/error-handling-foundation/review.md
@@ -1,0 +1,689 @@
+> Change class: **L** — reviewed as a full checklist.
+> Reviewed: `proposal.md`, 6 spec files (4 ADDED capabilities, 2 deltas), `design.md`.
+> Findings below were verified against the codebase, not inferred from the artifacts.
+
+## Completeness
+
+**Requirement/scenario coverage:** every requirement carries at least one
+scenario; `openspec validate error-handling-foundation --strict` passes. Counts:
+`feature-error-contract` 5/17, `result-layer-boundaries` 6/19,
+`repository-transaction-safety` 3/8, `http-result-rendering` 5/16,
+`pattern-matching-standard` 3 MODIFIED + 1 REMOVED + 2 ADDED,
+`typed-exception-handling` 3 MODIFIED + 2 ADDED.
+
+**MODIFIED deltas verified against the archive-replacement semantic.** All 7
+MODIFIED/REMOVED headers resolve exactly against their main specs. Scenario sets
+were diffed: 3 scenarios do not carry forward, each deliberately replaced because
+its behaviour changed — `Unique violation catches UniqueViolationError` and
+`Client misuse catches InterfaceError` (both said "raises", which the design
+forbids in a repository), and `Outbox relay dead-letters on any failure` (false —
+see Correctness 3). No scenario is lost silently.
+
+**Gaps found:**
+
+1. **No requirement governs `AppError` during the migration.** The specs forbid
+   annotating methods with `AppResult[T]`, but nothing stops a *new* `AppError`
+   subclass being added while 16 features still use the old system. The change
+   spans 17 openspec changes; over that window the hierarchy this change exists to
+   retire can legitimately grow, and every addition makes the last feature harder.
+   Needs a requirement freezing `AppError` to its existing subclasses.
+
+2. **No scenario covers the enforcement rules' own correctness.** `design.md` D12
+   flags that `no-match-on-result` does not enforce what its message claims, and
+   commits to a rewrite — but no spec requirement makes rule correctness
+   observable. Given that this change adds six new rules and the whole design
+   leans on them (a closed union is closed only because a gate says so), the gates
+   need a testable obligation.
+
+## Correctness
+
+3. **CONFIRMED — the deployed spec being modified contains a false scenario.**
+   `typed-exception-handling` asserts the outbox relay "dead-letters on any
+   failure … catches `Exception`". Measured: `src/app/shared/outbox/relay.py:139`,
+   the line that actually dead-letters, catches `(CeleryError, PostgresError)`.
+   The `except Exception` pair at `:76` and `:90` are the scan and listen loops,
+   which dead-letter nothing. The delta corrects this and names the partiality.
+   Correctly handled.
+
+4. **CONFIRMED — the `ty` claims in the artifacts are measured, not asserted.**
+   Re-verified during review: `ClassVar[SubscriptionCode] = "DUPLICATE_SUBSCRIPTION"`
+   produces `error[invalid-assignment]` even though the string value is *correct*,
+   and so do a typo and a member of the wrong enum — 3 diagnostics, with the
+   enum-member form clean. The guarantee is therefore stronger than
+   `feature-error-contract` claims: a code cannot be written as a string at all,
+   right or wrong. Worth stating that way in the spec.
+
+5. **MUST FIX — `ErrorKind` cannot express 401 or 403, and the design regresses
+   the security boundary.** `STATUS_BY_KIND` maps its five members to 422, 404,
+   409, 502, and 500/503. There is no route to 401 or 403.
+
+   This is not theoretical. `src/app/features/auth/service.py` raises
+   `UnauthorizedException` at **16 sites** ("Invalid credentials", token invalid,
+   token expired, session owner mismatch). The locked scope converts every
+   feature's service to Result-typed, so all 16 become typed failures rendered by
+   `render_result` — which, as specified, can only give them 422, 404, or 500.
+   The old system covers this correctly: `ErrorCode` has `UNAUTHORIZED`,
+   `FORBIDDEN`, `INVALID_TOKEN`, `TOKEN_EXPIRED`, `REFRESH_TOKEN_INVALID`, and
+   `UnauthorizedException`/`ForbiddenException` carry 401/403.
+
+   Shipping the five-member enum would mean the auth feature either cannot
+   migrate, or migrates by answering failed authentication with 422 — a
+   correctness and security regression, on the one feature the plan schedules last
+   and therefore discovers latest.
+
+   The three ways out: add `AUTHENTICATION` → 401 and `AUTHORIZATION` → 403;
+   or carve `auth` out of the Result conversion (contradicts the locked scope);
+   or let an error carry an explicit status (contradicts D6, and reintroduces the
+   per-endpoint drift being removed). Only the first is consistent with the rest
+   of the design, and it keeps boundary dispatch fixed-width — seven arms instead
+   of five, still independent of how many feature error types exist.
+
+6. **MUST FIX — `result-layer-boundaries`' "Every source file is classified" is
+   unsatisfiable as written.** The requirement says every file under `src/` falls
+   under exactly one row, and the scenario makes a file matching no row a gap to
+   close. But all 17 rows describe *error-handling* behaviour, and a large part of
+   the tree — DTOs, schemas, ORM models, config, enums, pure helpers — handles no
+   errors at all and matches no row. As written the requirement can never be
+   satisfied, which makes it unusable as a gate and invites the reader to
+   rubber-stamp it.
+
+   The user's scope decision was that every file has a *rule*, not that every file
+   returns a Result. Scope the requirement to files that construct, catch,
+   propagate, or render an error, and say explicitly that a file doing none of
+   those is out of scope.
+
+7. **Testability.** `repository-transaction-safety`'s scenario "The rule is
+   verifiable across the codebase" states that a count "is reportable" — that is a
+   property of a tool, not observable system behaviour. Either tie it to the
+   named gate or drop it; the requirement's other two scenarios already carry the
+   obligation.
+
+8. **Delta operations are correct.** REMOVED + ADDED for *"Service-layer Result
+   unwrapping uses match/case"* rather than MODIFIED is the right call: a MODIFIED
+   block must keep its header byte-identical, which would leave a header asserting
+   `match` above a body mandating `isinstance`, permanently, in the archived spec.
+   The REMOVED block carries both **Reason** and **Migration**, and the Migration
+   accounts for the two scenarios it drops.
+
+## Standards
+
+Checked against `.opencode/instructions/`:
+
+- **RESULT-PATTERN** — the artifacts adopt the *current* `.opencode/` rule
+  (`isinstance` + envelope, no raise) and extend it. They correctly do **not**
+  follow `.kiro/steering/RESULT-PATTERN.md`, which is one generation stale and
+  teaches `raise app_error_to_exception(error)` — the pattern
+  `no-raise-app-error-mapper` already flags at 34 sites. The change updates that
+  copy rather than leaving it to contradict the new rule. Good.
+- **EXCEPTION-RULES** — the response envelope stays `APIResponse` + `http_error()`;
+  D6 adds the transport status without replacing the envelope. `e.add_note()`
+  obligations in the `typed-exception-handling` delta are preserved verbatim.
+- **ARCHITECTURE-RULES** — layering is respected: rollback is placed in the
+  repository (D8) with the two alternatives rejected on stated grounds.
+- **PYTHON-TYPING-RULES** — PEP 695 `type` aliases and `ClassVar` are used as the
+  project does; no `# noqa` or `# type: ignore` is introduced, and per-feature exit
+  criterion 7 forbids reaching green with a suppression.
+- **No `match`/`case` on `Success`/`Failure`** — satisfied, and the review
+  instruction's own check is what the `pattern-matching-standard` delta brings the
+  deployed spec into line with.
+- **Secrets** — no `SecretStr` surface is touched.
+
+**INFO —** the agreed renderer sketch names its parameter `status_code`, which
+reads as the failure status but means the success status. `success_status` removes
+an ambiguity that will otherwise be misread at 67 call sites.
+
+## Risk
+
+- **Security boundary (see 5).** Blocking. The gap surfaces at the *last*
+  scheduled feature, so shipping the enum as-is buys 16 changes of false
+  confidence before the problem appears.
+- **Breaking change is correctly localised.** `"DB_ERROR"` → `DATABASE_ERROR` with
+  503 → 500 at 56 sites lands in one change with a before/after record, rather
+  than drifting across 17 releases. The status correction is the more important
+  half: clients are currently told to retry a dead transaction.
+- **Data integrity.** The rollback fix is the right shape and the alternatives are
+  rejected for the right reasons. Landing all 9 relational repositories here rather than per
+  feature is correct — it is error-type-independent, and staging it would leave
+  poisoned-commit paths open for the duration of the migration. `tasks.md` should
+  say this explicitly so it is not re-opened later as churn.
+- **Gate correctness is load-bearing (see 2).** The rewritten
+  `no-match-on-result` must reject `case Success(value):` while accepting
+  `case SubscriptionNotFoundError():` — the design endorses the second and
+  forbids the first, and a careless pattern would flag both. Verify against a
+  fixture holding both forms before trusting the "zero match-on-Result" count.
+- **Baseline is honestly recorded** (ty 2, ast-grep 4 + 34, pytest 400/439 with 2
+  collection errors) and scoped out of this change's ownership. Re-verified during
+  review: ast-grep reports exactly 34 `no-raise-app-error-mapper` and 4
+  `no-raw-httpexception`, matching `design.md`.
+- **`extra="forbid"` moves a stale `code=` keyword to a runtime `ValidationError`
+  raised inside an `except` block**, where it can mask the original error. Mitigated
+  in design (ty catches it statically first), and acceptable.
+
+## Must-fix list
+
+1. Add `AUTHENTICATION` (401) and `AUTHORIZATION` (403) to `ErrorKind`; update
+   `STATUS_BY_KIND`, the member list in `feature-error-contract`, and the mapping
+   in `http-result-rendering`. Record the deviation from the five-member design
+   and why the ground forced it.
+2. Scope `result-layer-boundaries`' file-classification requirement to files that
+   construct, catch, propagate, or render an error; state that files doing none of
+   those are out of scope.
+3. Add a requirement freezing `AppError` to its existing subclasses for the
+   duration of the migration.
+4. Add a requirement making the enforcement rules' own correctness testable, and
+   name the `case Success(value):` vs `case <ConcreteError>():` discrimination as
+   the case that must be verified.
+5. Strengthen `feature-error-contract`'s code-typing scenario to what was measured:
+   a bare string is rejected even when its value is correct.
+6. Rename the renderer's success-status parameter; drop or re-anchor
+   `repository-transaction-safety`'s "is reportable" scenario.
+
+**VERDICT:** CHANGES-REQUESTED — items 1–4 are blocking (1 is a security-boundary
+regression; 2 makes a requirement unsatisfiable; 3 leaves the retired hierarchy
+free to grow across 17 changes; 4 leaves the design's only enforcement mechanism
+unverified). Items 5–6 are non-blocking wording fixes. Do not write `tasks.md`
+until 1–4 are fixed in the artifacts.
+
+## Resolution
+
+All six items were fixed in the artifacts before `tasks.md` was written. What
+changed:
+
+1. **`ErrorKind` → 7 members.** `AUTHENTICATION` (401) and `AUTHORIZATION` (403)
+   added. Updated in `feature-error-contract` (member list plus two scenarios
+   distinguishing 401 from 403), `http-result-rendering` (mapping, and a scenario
+   asserting that converting `auth`'s service to Result does not change the status
+   a client sees), `design.md` D4 — which now records the deviation from the agreed
+   five-member set, the 16 measured raise sites that forced it, and the three
+   rejected alternatives — plus D5, the proposal's What Changes, and its Risks.
+2. **File classification scoped.** `result-layer-boundaries` now applies to files
+   that construct, catch, propagate, or render an error, with an explicit scenario
+   putting DTOs, schemas, models, settings and pure helpers outside it.
+3. **`AppError` frozen.** New requirement in `feature-error-contract`: no new
+   subclass and no new field for the migration's duration, with a scenario making
+   the subclass count monotonically decreasing and zero the completion signal.
+   `design.md` D13 records why deprecation-in-place fails here. Gate
+   `no-new-app-error-subclass` added to D12.
+4. **Gate correctness made a requirement.** New requirement in
+   `result-layer-boundaries`: every new or changed rule is verified against a
+   fixture holding both the forbidden construct and the nearest permitted one, and
+   a count from a corrected rule is re-measured rather than carried forward. It
+   names the `case Success(value):` versus `case <ConcreteError>():`
+   discrimination explicitly. `design.md` D14 records the reasoning.
+5. **Code-typing scenario strengthened** to what was measured: a bare string is
+   rejected even when its value is correct, so a code cannot be spelled by hand at
+   all. A second scenario covers a member of another feature's enum.
+6. **`success_status`** replaces `status_code` in the renderer's signature, with a
+   requirement clause and scenario forbidding the ambiguous name.
+   `repository-transaction-safety`'s "is reportable" scenario is re-anchored to the
+   gate's output on a migrated feature.
+
+Re-verified after the fixes: `openspec validate error-handling-foundation
+--strict` passes; 32 requirements and 120 scenarios across 6 spec files; all 7
+MODIFIED/REMOVED headers still resolve; the scenario diff still shows exactly the
+3 deliberate replacements and no silent loss.
+
+**VERDICT:** APPROVED — items 1–6 resolved in the artifacts and re-verified.
+`tasks.md` may be written. Two things carry forward into implementation as
+must-verify rather than must-decide: the rewritten `no-match-on-result` has to
+reject `case Success(value):` while accepting a concrete-type arm, and the 401/403
+statuses for `auth` have to be asserted end to end when that feature migrates,
+since that is the one place this change could silently regress a security
+boundary.
+
+---
+
+## Second pass — infrastructure scope
+
+Scope was widened after the verdict above, at the request's author's direction, to
+name `connections/`, `lifecycle/`, `middleware/`, `shared/` and `utils/`. The
+approval above does not cover that material, so it was reviewed on the same four
+axes. Reviewed: the new `shared-infrastructure-errors` capability (7 requirements,
+24 scenarios), the edits to `result-layer-boundaries` (classification table, two
+requirement bodies, one scenario), `repository-transaction-safety`'s session-dependency
+citation, `design.md` D15–D18, and the proposal's Why, What Changes, Scope, Impact
+and Risks.
+
+### Completeness
+
+The gap was real and it was not a wording gap. Four third-party wrappers under
+`shared/services/` — 31 raises of `APIException` subclasses, 20 catches every one of
+a library type, no `Result` — are structurally identical to a feature repository and
+were outside a classification that called itself total. So were the dispatcher every
+error passes through and the session dependency `repository-transaction-safety`
+exists to protect. A classification keyed on `features/` could not have found them.
+The fix is to key it on role, and `result-layer-boundaries` now carries a scenario
+stating that not living under `features/` is not grounds for exemption.
+
+Totals after the widening: 39 requirements, 149 scenarios across 7 spec files.
+`openspec validate error-handling-foundation --strict` passes. WHEN and THEN bullets
+pair at 149 each. No scenario header carries the wrong hash count. The one
+requirement with zero scenarios is the REMOVED block, which carries Reason and
+Migration instead — correct for the delta format.
+
+### Correctness
+
+Four claims in the first draft of this material were asserted from partial
+measurement and are corrected. All four were found by re-measuring rather than by
+re-reading, which is the only method that has worked on this change.
+
+9. **The `TaskDispatchError` family was described backwards.** The draft called it
+   "correctly rooted at `CeleryError` with **zero raise sites** — a declaration
+   implying handling that never happens." The count came from grepping
+   `raise TaskDispatchError`, which the base never is. Its two concrete subclasses
+   `UnregisteredTaskError` and `TaskPayloadValidationError` are each raised twice in
+   `connections/celery_registry.py`. The family is not a defect — it is the second
+   *correct* resolution, reachable through its root by the relay's existing
+   `except (CeleryError, PostgresError)` without any clause naming it.
+
+   This mattered beyond the fact. A rule written from the draft — "flag any family
+   with no catch clause naming it" — would have reported all three classes as
+   findings, and the endorsed pattern would have been gated against. Reachability is
+   now defined over ancestors, not exact names, with a scenario for an abstract base
+   that is deliberately never raised.
+
+10. **`shared/rag/` was not a third-party classifier and should not be converted
+    wholesale.** The draft's layer table put it alongside `shared/services/`. Of its
+    ~48 handlers, 17 catch bare `Exception` and **7 catch `ImportError`** as
+    optional-dependency guards; the genuine provider classification is confined to a
+    `_provider_failure` helper at 4 sites. It also raises builtins — `ValueError` ×6,
+    `TypeError`, `FileNotFoundError` — against 3 `APIException`-family raises. Only
+    the provider boundary owes a union.
+
+    This surfaced a category the classification was missing entirely: an
+    `except ImportError` that sets an availability flag is **capability detection, not
+    error handling**, and owes no classification. It now has its own row and its own
+    scenario, which also keeps every future gate from firing on optional-backend
+    probes.
+
+11. **`shared/services/` has a hard ordering constraint the migration plan did not
+    have.** `rate_limiter` is imported by `crawler` — the *third* feature in the
+    order — and `storage` by `profile`, `invoices` and `documents`. A feature
+    migrating while its shared dependency still raises `APIException` would have to
+    `try`/`except` around a call the project owns, which
+    `result-layer-boundaries` forbids. The plan had `shared/services/` merely
+    "after the foundation". It is now Phase 1a, explicitly before any feature, with
+    the reason recorded.
+
+12. **The two `except Exception` rules read as contradictory.**
+    `typed-exception-handling` preserves `except Exception` at degradation
+    boundaries; the new cache requirement forbids it in the cache helpers. Both are
+    right, and the distinction is now stated: a degradation boundary catches broadly
+    and *degrades* — fallback, `None`, re-enter the loop — while
+    `redis_func.py` catches broadly and *escalates*, converting a `TypeError` into a
+    500 labelled `DATABASE_ERROR`. Catching broadly to keep serving is endorsed;
+    catching broadly to relabel is not. A scenario now carries it, because a
+    reviewer reading only one of the two files would otherwise have to guess.
+
+13. **Confirmed, not corrected — the session dependency.**
+    `src/app/connections/postgres.py:241` reads exactly as
+    `repository-transaction-safety` assumed: yield, `await session.commit()`,
+    `except Exception: rollback; raise`, `finally: close`. A returned `Failure` is
+    not an escaping exception, so the swallowed-failure path reaches `commit()`. D16
+    now records why the obvious fix — teach the dependency about Results — is
+    unimplementable rather than merely undesirable: at the point it commits it holds
+    no `Result` and has seen no exception. Worth writing down because it is the first
+    idea every reader has.
+
+14. **Confirmed — the dispatcher exemption is necessary, not defensive.**
+    `middleware/global_exception_handler.py` contains **zero `except` blocks**; it is
+    invoked by registration. Any gate that locates error handling by matching
+    `except` is blind to the most important error-handling file in the repository, and
+    D14 requires it to say so instead of reporting a clean sweep. Its lines 166–200
+    also record, in detail, why the registration is split — Starlette routes the
+    `Exception` key to a different middleware than every other key, and FastAPI's
+    `setdefault(HTTPException, ...)` made the MRO walk resolve three classes early so
+    the `APIException` branch never ran — and end with an instruction not to simplify
+    it. D17 turns that comment into a rule.
+
+15. **`auth/repository.py` is a document store, and two claims rested on it not
+    being one.** Every artifact said "11 repositories catch `SQLAlchemyError`" and
+    "the 56 `DB_ERROR` sites correct from 503 to 500". Measured: of 11 repository
+    modules holding 12 classes, **9 are relational** with 74 SQLAlchemy handlers,
+    `users/repository.py` catches nothing, and `auth/repository.py` is MongoDB and
+    Redis — 13 `PyMongoError`/`DuplicateKeyError` handlers, 6 `RedisError`, zero
+    SQLAlchemy, zero `session` writes.
+
+    Two consequences, both material:
+
+    - **The rollback fix touches 9 modules, not 11.** MongoDB has no request-scoped
+      transaction under `get_postgres_db`, so there is nothing to roll back. The
+      requirement claimed to apply "to every existing `except` block"; it is now
+      scoped to the relational modules, with a companion requirement stating what a
+      document-store repository owes instead — classification, and explicitly *not* a
+      rollback, so it cannot be read as exempt.
+    - **The 503 → 500 correction is right for 49 sites and wrong for 7.** `auth`'s 7
+      `"DB_ERROR"` literals describe Mongo or Redis being unreachable, which is
+      genuinely retryable. Sweeping all 56 into one correction would have relabelled
+      a transient outage as a permanent failure **on the login path** — the same
+      feature the first review pass found was one enum short of a 401. A scenario
+      now pins the retryable classification for those 7.
+
+    The root cause is the same as finding 9's: a count taken from one grep pattern
+    (`repository.py`, `SQLAlchemyError`) and generalised to a claim about a
+    population. `credits/` also holds two repositories under a `repositories/`
+    subdirectory that the file-name pattern missed. D8 now records the per-store
+    split rather than treating "repository" as one kind of thing.
+
+### Standards
+
+- The new capability follows `feature-error-contract`'s rules rather than inventing
+  parallel ones: per-module StrEnum, flat siblings, closed union, no cross-module
+  code imports. D15's rule — the module that classifies owns the union — subsumes
+  the feature case rather than special-casing `shared/`.
+- `ErrorKind` is unchanged. The shared modules classify into the same seven kinds,
+  so boundary dispatch stays fixed-width and the review's item-1 fix is not
+  disturbed.
+- No requirement here asks for a `# noqa` or `# type: ignore`, and none proposes
+  rewriting `lifespan.py` or the global handler — both are measured to be correct,
+  and the change makes their behaviour a rule while touching no code in them.
+
+### Risk
+
+- **The widening is bounded by role, not by directory.** `shared/` is 111 files, and
+  "in scope" could be misread as a mandate to convert the LangGraph layer. The
+  proposal states scope per subtree and D15's rule excludes the graph nodes by
+  construction. This is the residual risk most worth re-checking at implementation.
+- **`utils/cache/redis_func.py` is reachable from no request path** — only
+  `utils/cache/__init__.py` and `examples/redis_examples.py` import it. Its 27
+  `DatabaseException` raises for Redis failures are a latent misclassification and a
+  bad exemplar, not a live 500. Scheduled, but it should not be carried in the risk
+  register as a production fault, and this is stated in both design and proposal.
+- **Five families are caught nowhere.** `CircuitBreakerOpenError`,
+  `IdempotencyLockError`, `AgentMemoryError`, `CogneeSetupError` and
+  `StateSchemaVersionError` all have raise sites and zero catch sites. On a request
+  path they reach the unhandled-500 branch; in a worker, nothing. This is the
+  highest-severity finding in the infrastructure scope and it lands in Phase 1.
+- **The blind spot was found by the request's author, not by the plan.** That is the
+  second directory-shaped assumption in this change to have hidden live
+  error-handling code. Recorded as a risk in the proposal so the pattern is
+  available to whoever writes the per-feature changes, rather than being
+  rediscovered a third time.
+
+**VERDICT:** APPROVED — the infrastructure scope is coherent with the four
+capabilities approved above, and the five errors found in its first draft are
+corrected in the artifacts and re-validated. Carried forward into implementation:
+the family-reachability gate must be checked against `celery_registry.py`'s
+correctly-rooted family before its counts are trusted (D14 applied to D18's own
+rule); `shared/services/` must land before `crawler` or the try/except rule is
+violated by construction; and the `"DB_ERROR"` migration must be split 49/7 by store,
+because the two halves correct in opposite directions.
+
+**Method note.** Five of the five errors in this pass came from generalising a count
+taken with one grep pattern. Findings 9 and 15 are the same mistake twice — `raise
+TaskDispatchError` missed the subclasses, `-name 'repository.py'` missed
+`credits/repositories/`, and `SQLAlchemyError` treated a Mongo repository as
+relational. The rule that would have caught all five: before a count becomes a claim
+about a population, enumerate the population by a second, structurally different
+query and reconcile the two. That is D14's principle applied to measurement rather
+than to gates, and it belongs in the per-feature changes' method as well.
+
+
+
+---
+
+## Third pass — the spine's own ground, before tasks
+
+Written while enumerating concrete task targets. Four findings; two are corrections
+to approved artifacts, one is a spec gap that would have fired a gate on correct
+code, one is a live defect the design now inherits.
+
+16. **Corrected — the shared spine is not new.** Both earlier passes let
+    `app/shared/errors/` "is introduced" stand, in the proposal's What Changes, its
+    Scope, its Impact, and design Phase 1. `src/app/shared/result/` already holds
+    `errors.py`, `types.py`, `mappers.py` and `logging.py`, and
+    `result-layer-boundaries` already classifies `shared/result/errors.py` as the
+    vocabulary layer — so `feature-error-contract` naming a different package put two
+    approved specs in direct conflict about where `ErrorKind` lives. Neither pass
+    caught it because both reviewed the plan against itself. Fixed in
+    `feature-error-contract` (with two new scenarios), the proposal at three sites,
+    design Phase 1, and D19.
+
+17. **The five-kind vocabulary was the existing hierarchy read back.**
+    `ValidationAppError`, `NotFoundAppError`, `ConflictAppError`,
+    `InfrastructureAppError` and `ExternalServiceAppError` each already declare
+    `kind: Literal[...]` — the same five values scoping proposed. This does not change
+    a requirement, and it strengthens ADR-003 rather than weakening it: the two
+    missing members are missing from the *code*, which is why `auth`'s 16
+    `UnauthorizedException` raises route around `AppError` entirely instead of
+    classifying into it. It also resizes the work honestly — the migration surface is
+    **123 construction sites** (72 `InfrastructureAppError`), not five class
+    definitions, and they retire per feature.
+
+18. **Gap closed — a pre-service policy guard was unclassified.**
+    `features/crawler/router.py` raises `TooManyRequestsException` at three sites after
+    `check_rate_limit` returns `(False, info)`. No `Result` is produced and no
+    exception is caught, so it is not error handling — but a "routers render, do not
+    raise" gate reads it as three violations in a file that is correct. It is the same
+    shape as the `except ImportError` capability-flag row, and it is now a row in the
+    layer table plus a scenario. Seven kinds still suffice: 429 never crosses the
+    Result boundary, so no eighth kind is needed. Had the gate been written first, the
+    likely repair would have been an eighth kind for a construct that owes no
+    classification at all.
+
+19. **Sixth instance of the Method-note error — this time in the ordering rationale.**
+    Phase 1a justified itself with "`rate_limiter` is imported by `crawler`, the third
+    feature in the order". `shared/services/rate_limiter.py` raises nothing and catches
+    nothing; it returns `tuple[bool, dict]`. The 31/20 total for `shared/services/` was
+    right and the per-module attribution was invented. Measured: `storage` 21/15,
+    `tavily` 8/3, `mailer` 2/2, `rate_limiter` 0/0. The conclusion survives — Phase 1a
+    must still precede `crawler` — but via **`tavily.py`**, whose `search` the package
+    `__init__` re-exports and `crawler/service.py:18` imports. Also measured while
+    fixing it: `mailer.py` has no importer outside `shared/services/`, so it blocks no
+    feature; 4 of `tavily.py`'s 8 raises are pre-flight argument guards rather than
+    boundary classification; and 17 of `storage.py`'s 21 are `ServiceUnavailableException`,
+    which keeps its 503 under the new kinds, so that conversion has no observable
+    break. All of this is now in the Phase 1a table.
+
+20. **Live defect the design now inherits, not one it creates.**
+    `features/ingestion/service.py:86` constructs `AppError(code="UNKNOWN",
+    message=str(failure))`. The base declares no `kind` field, and `mappers.py`'s final
+    `case AppError():` arm maps it to `ValidationException` — so an unknown internal
+    failure is reported to the client as **422**, telling the caller to fix input for a
+    fault that is not theirs. It corrects to 500 under `STATUS_BY_KIND`. It is also the
+    only object in the codebase that would `AttributeError` on `error.kind`, which is
+    harmless today only because **nothing dispatches on `kind` anywhere** — the field
+    is declared and never read. The renderer is its first consumer, so this site must
+    be fixed before `render_result` ships, not with `ingestion`'s own change.
+
+**VERDICT: APPROVED.** The four original capabilities and the infrastructure scope are
+unchanged in substance; this pass corrected where the spine lives, classified one
+construct that would have produced three false violations, and repaired the Phase 1a
+rationale without changing its conclusion. Added to the carry-forward list: the
+`ingestion/service.py:86` kindless instance is a Phase 1 task, not a Phase 2 one.
+
+**Method note, second entry.** Finding 19 is the sixth error of the form the first
+Method note named, and finding 16 shows the review procedure's own blind spot: two
+passes reviewed the plan for internal consistency and neither opened the directory the
+plan proposed to create. Reviewing a plan against itself cannot find a claim that is
+coherent and false. The check that found both was mechanical — `ls` the path the plan
+says it will create, and read the module it says it will extend — and it belongs at the
+top of every subsequent change's review, before any reasoning about the plan's content.
+
+---
+
+## Fourth pass — the five directories the owner added after approval
+
+Scope changed after the third pass: `src/app/api`, `src/app/config`,
+`src/app/examples`, `src/database` and `src/tasks` were declared out of scope, recorded
+as such in `HANDOFF.md` §9, and then brought back in. `src/mcp_core` stays out by
+decision; `src/lynk` is out by nature.
+
+This pass enumerated all five before writing anything — 22 `.py` files, 12 raises, 47
+`except` clauses — and found five things worth recording.
+
+### Findings 21–25
+
+**21. `HANDOFF.md` §9 asserted the opposite of the current scope.** It read
+"Explicitly out of scope, by the owner's decision — do not touch, do not report as a
+coverage gap" and listed all five. A handoff document is the one artifact an
+implementing agent is told to trust over its own judgement, so a stale scope boundary
+there is worse than a stale count anywhere else. Corrected, with D20 named as the place
+that tabulates the dispositions.
+
+**22. `design.md` contradicted itself and `tasks.md` on when `utils/cache/` lands.**
+The Migration Plan listed "`utils/cache/` with `examples/redis_examples.py`" under
+*Deferred to their own changes*, while the risk register two sections earlier said
+"Scheduled with the foundation anyway" and `tasks.md` 7.5 schedules the
+reclassification in this change. Two of three said foundation, and the schedule is the
+one with a task attached, so the deferral line was the stale one. This was found only
+because folding `examples/` in forced the question of *which* change fixes its 8
+`except DatabaseException` catches — the contradiction had survived three passes because
+nothing else needed the answer.
+
+**23. The `src/tasks/` degradation count was wrong in exactly the way the pass-2 Method
+note describes.** A summed grep gave "6 `# noqa: BLE001` with a written reason";
+enumerating the sites gave **2** (`agent_memory_tasks.py:72`, `billing_tasks.py:134`),
+with 3 more carrying a bare `# noqa: BLE001` and no reason. Seventh instance in this
+change of a total being right while its attribution was invented. Reconciled by two
+structurally different queries — one keyed on an em-dash after the code, one on
+`(—|--) ` — which disagreed at first (54 vs 53) because `processor.py` uses an ASCII
+hyphen and `shell.py` writes its reason after a second code. Both resolve to the same
+population: **62 sites, 55 with a reason, 7 without** — 4 in
+`features/subscriptions/service.py`, 3 in `src/tasks/billing_tasks.py`.
+
+That reconciliation changed the requirement rather than just its numbers. At 55 of 62,
+"a deliberate degradation names its reason" is not a rule this change invents — it is
+the repository's existing convention, followed by the very file the change designates
+as the reference degradation boundary (`lifespan.py:234`). The requirement went from
+*proposing* a practice to *writing down* one, and the 7 exceptions became a finite,
+named worklist instead of a category.
+
+**24. `app/examples/` is exempted from the error-handling lint rules in writing, and
+that is the finding.** `pyproject.toml`'s `per-file-ignores` disables `BLE001`, `E722`,
+`B904`, `TRY201`, `TRY300`, `TRY301`, `TRY400` and `S112` for `src/app/examples/*.py`,
+with a second block for `rag_agent_advanced.py` whose `BLE001` is already dead. So
+`ruff check src/app/examples/` reports "All checks passed!" while `ast-grep scan`
+reports 4 `error`-level `no-raw-httpexception` violations in `redis_examples.py` —
+ast-grep is simply the only gate there with no per-path ignore.
+
+The first three passes treated the 4 ast-grep violations as the defect. They are the
+symptom. The defect is that the directory whose entire purpose is to be copied has been
+excused from the rules the copies will be held to, and a reader checking "is
+`examples/` clean?" with the project's primary linter gets a green answer.
+
+**25. `BLE001` already encodes the degrade-versus-escalate distinction this change
+argues for.** It does not fire on a blind `except` that ends in a bare `raise` —
+`middleware/server_middleware.py:100` catches `Exception`, logs with `.exception()`,
+re-raises, and needs no suppression. That is the same line D14/the cache requirement
+draw between *catching broadly to keep serving* and *catching broadly to relabel*, and
+it was already in the linter. Any gate written for the degradation rule has to spare
+that shape or it will contradict a tool the project already runs.
+
+### What did not change
+
+The five directories added **no new capability**. Every one of their rules fits an
+existing one — `shared-infrastructure-errors` for the five requirements, four table rows
+and four scenarios in `result-layer-boundaries`. That is a positive signal about D15's
+framing: keying the classification on *role* rather than directory meant a scope
+expansion of five trees needed no structural change to the spec, only more rows.
+
+Nothing in `feature-error-contract`, `http-result-rendering`,
+`pattern-matching-standard` or `repository-transaction-safety` was touched, and no ADR
+was reopened. D20 is additive.
+
+**VERDICT: APPROVED.** The widened scope is coherent with the six ADRs and the seven
+capabilities. Section 9's 16 tasks are almost entirely exemption-writing and
+suppression-removal rather than conversion, which is why they add a fifth small PR
+instead of enlarging any existing one.
+
+**Method note, third entry.** Findings 21 and 22 are a class the first two notes do not
+cover: **a scope change invalidates artifacts that were correct when written, and the
+handoff document is the most dangerous place for that to happen.** The two rules so far
+both concern measuring the *code*. This one concerns measuring the *plan against its own
+decisions*: when scope moves, grep every artifact for the boundary it used to state —
+`grep -rn "out of scope" .` found finding 21 in one call, and grep for the directory
+names found finding 22.
+
+Finding 24 adds a third measurement rule, and it is ADR-005 in a second form. ADR-005
+says a gate is not trusted until it is shown to permit and to forbid. That catches a
+rule whose *pattern* is wrong. It does not catch a working rule *pointed away from the
+code* — `per-file-ignores`, a `ruleDirs` omission, a rule-level path filter. Both
+produce the identical artefact: a clean run that reads as coverage. So: **before citing
+a gate's zero, read its exclusion list.** Task 10.7 makes this a step in the change
+rather than advice.
+
+---
+
+## Fifth pass — 2026-08-31, the plan versus the branch
+
+The previous four passes reviewed the plan against the *code*. This one reviews it
+against the *implementation of itself*, which had started while the fourth pass was
+being written.
+
+**26. The handoff described an unstarted change, and 26 of its tasks were already
+done.** `HANDOFF.md` opened "Your job is the 95 tasks in `tasks.md`". Two things were
+wrong. The total is **97** — a per-section sum reconciles (13+7+11+5+8+9+7+7+16+7+7),
+and `grep -c '^- \[ \] '` returned 71 because 26 boxes are already `[x]`. And the work
+was not prospective: sections 1 (13/13), 2 (7/7) and 4 (5/5) plus task 3.1 are complete
+and committed, each with a `> **DONE:**` block naming the sites it touched. An agent
+handed that file would have re-audited nine repositories that were already fixed.
+
+The PR table carried the same arithmetic error independently: PR 4 was listed at 25
+tasks against sections 6+7+8 = 9+7+7 = **23**.
+
+**27. The five-PR split no longer maps onto the branch history, and could not be
+retrofitted.** The table assigns section 1 to PR 1, sections 2+3 to PR 2, and sections
+4+5 to PR 3. On the branch, `58422c1` contains sections **2 and 4 together, plus task
+3.1** — one commit spanning three planned PRs. This is not a deviation to correct; the
+seams the table cut on were dependency seams, and nothing about landing 2 and 4 together
+violates a dependency. The table was simply written before the history existed. §3 now
+records what landed and splits only the remainder (A–E), which preserves the reviewable-
+unit goal without asking anyone to rewrite four commits.
+
+**28. Every planning artifact except `tasks.md` is untracked.** `proposal.md`,
+`design.md`, `adrs.md`, `review.md`, `specs/` and `HANDOFF.md` are all `??` in
+`git status`. `tasks.md` is tracked only because `0ca39ea` committed the section 1 ticks.
+So the branch currently carries 97 ticked-and-unticked checkboxes, four implementation
+commits, and no proposal, no ADRs and no spec deltas — a reviewer sees the answers with
+none of the reasoning, and `openspec archive` at the end would have nothing to fold.
+
+**29. Task 3.1's deferred re-measure is now done, and the answer is a real zero.** 3.1's
+own `DONE` block said "DONE (partial…) — full violation re-measure deferred". Completed
+here: the corrected `no-match-on-result` reports **0 violations in `src/`, 0 in
+`tests/`**, and `rg 'case\s+(Success|Failure)\s*\('` over the same trees independently
+returns 0. Both queries agree, so this is the honest zero, not ADR-005's "the rule looked
+for something nobody writes" — nothing in the codebase matches on a `Result`, which is
+what ADR-002's 122 `isinstance` unwrap sites predicted.
+
+The rule's behaviour was also verified two-sided against a probe: it flags
+`case Success(value)`, `case Failure(err)`, `case Success()` and `case Failure()`, and
+spares `case SubscriptionNotFoundError():` and `case SubscriptionConflictError(code=c):`
+— exactly ADR-002's stated obligation. But the probe was a throwaway in `/tmp`, so the
+repo still holds nothing that would catch a future re-narrowing of the regex. That is
+task 3.2, and it is the reason ADR-005 asks for a *committed* fixture rather than a
+demonstration.
+
+Applying ADR-005's second form to this pass's own measurement: `ast-grep scan` reads
+**411 of the 427** `.py` files under `src/ tests/`. The 16 it skips are exactly the 16
+zero-byte `__init__.py` files, and `sgconfig.yml` declares no path exclusion — so unlike
+ruff, ast-grep's coverage of everything with content in it is total. Consequence for the
+plan: `no-match-on-result`'s severity is `warning`, as is `no-raise-app-error-mapper`,
+while the other three rules are `error`. The seven new rules should pick deliberately.
+
+### What did not change
+
+No spec, no ADR, no requirement and no scenario. The counts stand at **45 requirements /
+180 scenarios** across seven capabilities, WHEN = THEN = 180, and
+`openspec validate error-handling-foundation --strict` reports valid with 6/6 artifacts
+complete. This pass edited only `HANDOFF.md` (§ intro, 3, 6) and `tasks.md`'s 3.1 `DONE`
+block. Findings 26–28 are all bookkeeping in the one artifact an implementing agent is
+told to trust over its own judgement — which is precisely where finding 21 lived too.
+
+**VERDICT: APPROVED.** The plan is sound and the first 26 tasks implement it faithfully.
+Two things must happen before PR A opens: commit the planning artifacts, and land task
+3.2's fixture pair.
+
+**Method note, fourth entry.** The three existing rules assume the plan is the only thing
+moving. Once implementation starts, **the plan and the branch are two moving objects, and
+the handoff is where they are reconciled.** Two concrete probes, both cheap:
+
+1. **Never state a task total from memory or from another document — derive it, twice.**
+   `grep -c '^- \[ \] '` counts only the *open* boxes; the total needs
+   `grep -cE '^- \[( |x)\] '`, and a per-section sum is the reconciling second query. The
+   disagreement between those two numbers (71 vs 97) is what revealed that implementation
+   had started at all. It was not reported by anyone.
+2. **A `DONE` block that says "partial" is a debt, and nothing collects it.** Task 3.1
+   was ticked `[x]` while its own annotation deferred the re-measure. `--strict` cannot
+   see that; `openspec status` counts it complete. Grep the `DONE` blocks for "partial",
+   "deferred" and "TODO" before opening the PR that contains them.

--- a/openspec/changes/error-handling-foundation/specs/feature-error-contract/spec.md
+++ b/openspec/changes/error-handling-foundation/specs/feature-error-contract/spec.md
@@ -1,0 +1,218 @@
+## Purpose
+
+Defines the shape every domain error in this system must take: a frozen Pydantic
+model whose classification is fixed at the class rather than supplied per call
+site, gathered into a per-feature closed union that a type checker can verify a
+`match` has covered exhaustively.
+
+## ADDED Requirements
+
+### Requirement: Error classification SHALL be a class constant, not a constructor parameter
+
+`kind`, `code`, and `retryable` SHALL be declared as `typing.ClassVar` on the
+error type. They SHALL NOT be Pydantic fields, SHALL NOT appear in
+`model_fields`, and SHALL NOT be acceptable as constructor keyword arguments.
+
+The base SHALL set `model_config = ConfigDict(extra="forbid", frozen=True)` so
+that passing a classification value at a construction site raises
+`ValidationError` rather than silently overriding the class constant.
+
+`code` SHALL be typed as the feature's own StrEnum, never as a bare `str`, so a
+value outside that enum is a type error before it is a runtime value.
+
+#### Scenario: Classification is absent from the model fields
+- **WHEN** a concrete error type declares `code`, `kind`, and `retryable` as `ClassVar`
+- **THEN** `model_fields` contains only the instance data fields, and none of `code`, `kind`, or `retryable`
+
+#### Scenario: Supplying a code at the construction site is rejected
+- **WHEN** a caller constructs an error type passing `code="ANYTHING"` as a keyword argument
+- **THEN** construction raises `ValidationError` because `extra="forbid"` refuses the unknown key, so a mistyped code cannot be represented
+
+#### Scenario: A code cannot be written as a string at all
+- **WHEN** a concrete error type assigns `code: ClassVar[SubscriptionCode] = "DUPLICATE_SUBSCRIPTION"` as a string literal, even though that string is the correct value of an existing enum member
+- **THEN** `uv run ty check src/` reports `invalid-assignment`, because a `str` literal is not assignable to the enum type — so a code cannot be spelled by hand whether it is right or wrong, and the enum member must be referenced
+
+#### Scenario: A code from another feature's enum is a type error
+- **WHEN** a concrete error type assigns a member of a different feature's code enum
+- **THEN** `uv run ty check src/` reports `invalid-assignment`, so codes cannot leak between features even by accident
+
+#### Scenario: An error instance is immutable
+- **WHEN** code assigns to any field of a constructed error instance
+- **THEN** the assignment raises `ValidationError` because the model is frozen
+
+#### Scenario: Classification does not leak into the serialised payload
+- **WHEN** an error instance is serialised with `model_dump()`
+- **THEN** the output contains only the instance data fields, and the `code`, `kind`, and `retryable` constants are read from the class when the boundary needs them
+
+### Requirement: Each feature SHALL own a closed error union in its own errors.py
+
+Every feature SHALL declare `src/app/features/<name>/errors.py` containing a
+`<Feature>Code` StrEnum, its concrete error types, a closed union
+`type <Feature>Error = A | B | C` naming every one of them, and
+`type <Feature>Result[T] = Result[T, <Feature>Error]`.
+
+Repository and service methods SHALL be annotated with `<Feature>Result[T]`.
+They SHALL NOT be annotated with `AppResult[T]`, whose error side is pinned to
+the open `AppError` base and therefore cannot be exhaustively matched.
+
+No feature SHALL import another feature's error types, error union, or code enum.
+Where two features genuinely exchange a failure, the calling feature SHALL
+translate it into a member of its own union at the call boundary.
+
+#### Scenario: A repository method carries the feature's own Result type
+- **WHEN** a subscriptions repository method is annotated
+- **THEN** its return type is `SubscriptionResult[Subscription]`, not `AppResult[Subscription]`
+
+#### Scenario: Every concrete error type appears in the union
+- **WHEN** a feature's `errors.py` declares a concrete error type
+- **THEN** that type is named in the feature's `type <Feature>Error` union, and a type declared but omitted from the union is a rule violation
+
+#### Scenario: Cross-feature failure is translated, not re-exported
+- **WHEN** a service in one feature receives a `Failure` from a collaborator in another feature
+- **THEN** it constructs an error from its own union to carry that failure onward, and does not import or propagate the collaborator's error type
+
+### Requirement: Concrete error types SHALL be flat siblings with no inheritance between them
+
+Every concrete error type SHALL inherit directly from `FeatureError` and from
+nothing else. No concrete error type SHALL inherit from another concrete error
+type, and no intermediate error base SHALL be introduced between `FeatureError`
+and a concrete type — including for the sole purpose of sharing fields.
+
+The reason is not style. `match` class patterns are `isinstance`-based, so a
+broader arm placed before a narrower one silently makes the narrower arm
+unreachable, and a type checker still reports that `match` exhaustive because
+every case was covered. There is no static or runtime signal for a shadowed arm;
+the only symptom is the wrong branch's side effects running.
+
+Where several error types in a feature need the same field, the field SHALL be
+repeated on each type, or added to `FeatureError` if it is genuinely universal.
+
+#### Scenario: Introducing a shared intermediate base is rejected
+- **WHEN** a feature adds `class ConflictError(FeatureError)` and has `VersionConflictError` inherit from it to share fields
+- **THEN** the enforcement rule reports a violation, because a `case ConflictError():` arm would silently shadow `case VersionConflictError():`
+
+#### Scenario: A shared field is duplicated rather than inherited
+- **WHEN** three error types in one feature each need a `subscription_id` field
+- **THEN** each declares the field on itself, and no intermediate base is created to hold it
+
+#### Scenario: The existing deep chains are flattened as their feature migrates
+- **WHEN** a feature migrates that owns one of the 28 existing concrete-inherits-concrete chains
+- **THEN** that feature's chains are flattened to direct children of `FeatureError` in the same change, and none survives the migration
+
+### Requirement: A match over a feature's error union SHALL be provably exhaustive
+
+Code that dispatches on a feature's error union for business logic SHALL `match`
+on the union and SHALL close the match with `case _ as unreachable:
+assert_never(unreachable)`.
+
+Adding a member to a feature's union without adding its arm to an existing
+exhaustive match SHALL fail `uv run ty check src/`. This is the property the
+whole design exists to buy, and it SHALL be verified rather than assumed.
+
+#### Scenario: An exhaustive match type-checks
+- **WHEN** a match covers every member of the feature's error union and closes with `assert_never`
+- **THEN** `uv run ty check src/` reports no diagnostic for that match
+
+#### Scenario: A missing arm is caught by the type checker
+- **WHEN** a member of the feature's error union has no arm in a match closed by `assert_never`
+- **THEN** `uv run ty check src/` reports `type-assertion-failure`, naming the uncovered member as the inferred type of the `assert_never` argument
+
+#### Scenario: Adding a new error type breaks every stale match
+- **WHEN** a new error type is added to a feature's union
+- **THEN** every existing exhaustive match over that union fails type-checking until an arm is added, so no dispatch site can silently ignore the new failure mode
+
+### Requirement: ErrorKind SHALL be the only shared classification vocabulary
+
+`app/shared/result/` SHALL define `ErrorKind` as a StrEnum with exactly the
+members `VALIDATION`, `NOT_FOUND`, `CONFLICT`, `AUTHENTICATION`, `AUTHORIZATION`,
+`INFRASTRUCTURE`, and `EXTERNAL_SERVICE`. It SHALL be the only error vocabulary
+shared across features.
+
+`ErrorKind` SHALL live in the existing `app/shared/result/` package, not in a new
+one. That package already owns the shared error vocabulary — `errors.py` holds
+`AppError` and its five subclasses, `types.py` the `AppResult` alias, `mappers.py`
+the exception bridge, `logging.py` the failure logger — and `result-layer-boundaries`
+already classifies `shared/result/errors.py` as the vocabulary layer. A second
+vocabulary package would give the codebase two competing homes for the same concept
+during the exact window in which the old one is being retired.
+
+The five existing subclasses SHALL be read as the predecessor of this enum, not as
+an unrelated hierarchy. `ValidationAppError`, `NotFoundAppError`, `ConflictAppError`,
+`InfrastructureAppError` and `ExternalServiceAppError` each declare a
+`kind: Literal[...]` field, and their five values are exactly the five kinds this
+requirement extends to seven. The migration therefore moves `kind` from a
+per-subclass `Literal` field to a `ClassVar` on flat siblings, and adds the two
+members the old hierarchy could not express — it does not introduce the concept.
+
+`AppError` itself SHALL NOT be treated as carrying a kind. The base declares no
+`kind` field, so `error.kind` on a bare `AppError` instance raises
+`AttributeError`; `app/features/ingestion/service.py:86` constructs exactly that
+(`AppError(code="UNKNOWN", message=str(failure))`). Any kind-keyed adapter SHALL
+therefore be unreachable from a bare-base instance by the time it ships, either
+because the instance is gone or because the base is no longer constructible.
+
+`AUTHENTICATION` and `AUTHORIZATION` are separate members because the boundary
+must distinguish "we do not know who you are" from "we know, and you may not do
+this" — they are different HTTP statuses, different log severities, and different
+client behaviours. No other kind can express either, and a system that cannot
+express them answers a failed login with a validation error.
+
+Boundary adapters — HTTP status selection, log severity, retry eligibility —
+SHALL match on `kind`, never on a feature's concrete types, so that boundary code
+stays a fixed-width dispatch no matter how many feature error types exist.
+Feature business logic SHALL match on the concrete type, never on `kind`.
+
+#### Scenario: The boundary dispatches on kind
+- **WHEN** the HTTP boundary selects a status code for a failure
+- **THEN** it reads `error.kind` and consults `STATUS_BY_KIND`, and does not reference any feature's concrete error type
+
+#### Scenario: Feature logic dispatches on the concrete type
+- **WHEN** a subscriptions service decides whether a failure is retryable business state or a hard stop
+- **THEN** it matches on the concrete error types in `SubscriptionError`, not on `kind`, because two error types sharing a `kind` can need opposite handling
+
+#### Scenario: A failed authentication is not a validation failure
+- **WHEN** an authentication service returns a failure for invalid credentials, an invalid token, or an expired token
+- **THEN** the error's kind is `AUTHENTICATION`, and the boundary renders 401 rather than 422
+
+#### Scenario: A permission denial is distinguished from an identity failure
+- **WHEN** a service returns a failure because an authenticated caller may not act on a resource
+- **THEN** the error's kind is `AUTHORIZATION` and the boundary renders 403, distinct from the 401 an `AUTHENTICATION` failure produces
+
+#### Scenario: Adding feature error types does not grow the boundary
+- **WHEN** a feature adds three new error types to its union
+- **THEN** `STATUS_BY_KIND` and every other kind-keyed adapter are unchanged, because each new type declares one of the seven existing kinds
+
+#### Scenario: The shared vocabulary has exactly one home
+- **WHEN** a reviewer looks for the definition of `ErrorKind` or `STATUS_BY_KIND`
+- **THEN** it is under `app/shared/result/`, alongside the `AppError` hierarchy it replaces, and no second shared error-vocabulary package exists
+
+#### Scenario: A kind-keyed adapter never receives a kindless error
+- **WHEN** the HTTP renderer or any other kind-keyed adapter is reached by a failure produced before the migration completes
+- **THEN** that failure carries a `kind`, and no code path can hand the adapter a bare `AppError` whose `kind` attribute does not exist
+
+### Requirement: The AppError hierarchy SHALL be frozen for the duration of the migration
+
+From this change until the last feature has migrated, no new subclass of
+`AppError` SHALL be added, and no new field SHALL be added to an existing one.
+New error types SHALL be declared as `FeatureError` subclasses in a feature's
+`errors.py`.
+
+The migration spans many changes. Over that window the open hierarchy being
+retired can otherwise legitimately grow, and every addition enlarges the work
+remaining for the features that have not yet migrated. Freezing it makes the
+hierarchy strictly shrink.
+
+An `AppError` subclass SHALL be deleted in the change that migrates its owning
+feature, not deprecated in place.
+
+#### Scenario: A new AppError subclass is rejected
+- **WHEN** a change adds a class inheriting from `AppError` or one of its subclasses
+- **THEN** the enforcement gate reports a violation and directs the author to the owning feature's `errors.py`
+
+#### Scenario: An unmigrated feature may still use the old types
+- **WHEN** a feature that has not yet migrated constructs one of the existing `AppError` subclasses
+- **THEN** that is permitted, because the alternative is a partial migration carrying two error systems inside one feature
+
+#### Scenario: The hierarchy shrinks monotonically
+- **WHEN** any feature's migration change is complete
+- **THEN** the total number of `AppError` subclasses in the codebase is strictly lower than before that change, and reaches zero when the last feature migrates

--- a/openspec/changes/error-handling-foundation/specs/http-result-rendering/spec.md
+++ b/openspec/changes/error-handling-foundation/specs/http-result-rendering/spec.md
@@ -1,0 +1,139 @@
+## Purpose
+
+Defines how an HTTP endpoint turns a typed failure into a response: one shared
+renderer that derives the real status code from the error's kind and emits the
+project's standard error envelope, so a service never has to raise in order for a
+client to receive the right status.
+
+## ADDED Requirements
+
+### Requirement: A router SHALL render a Result rather than raise on an expected failure
+
+An endpoint that calls a Result-typed service SHALL open the `Result` and hand a
+`Failure` to the shared renderer. It SHALL NOT convert an expected failure into an
+exception for the global exception handler to catch.
+
+Raising remains correct for the cases where control flow must be abandoned rather
+than answered: a FastAPI dependency rejecting a request before the endpoint body
+runs, and a genuinely unexpected exception reaching the global handler.
+
+#### Scenario: An expected failure is rendered
+- **WHEN** an endpoint receives `Failure(<Feature>NotFoundError(...))` from its service
+- **THEN** it returns the rendered error response directly, and no exception is raised
+
+#### Scenario: A dependency still raises
+- **WHEN** an authentication dependency determines the caller is not authorised
+- **THEN** it raises, because a dependency has no response to return and raising is the only way to stop the request
+
+#### Scenario: An unexpected exception still reaches the handler
+- **WHEN** an unanticipated exception escapes an endpoint
+- **THEN** the global exception handler renders it, and this requirement does not apply
+
+### Requirement: The rendered response SHALL carry the real HTTP status, not only a status in the body
+
+The renderer SHALL set the response's HTTP status code. A response describing a
+failure SHALL NOT be transmitted with a 2xx status.
+
+This corrects a live defect: the existing `http_error` helper writes the status
+into the JSON body and returns a plain object, so an endpoint that returns it
+produces **HTTP 200** with `"success": false`. Clients, proxies, retry
+middleware, and monitoring all key on the transport status, and every one of them
+currently reads these failures as successes.
+
+#### Scenario: A not-found failure returns 404
+- **WHEN** an endpoint renders a failure whose kind is `NOT_FOUND`
+- **THEN** the HTTP response status is 404, and the body's status field agrees with it
+
+#### Scenario: The transport status and body status agree
+- **WHEN** any failure is rendered
+- **THEN** the status in the response body equals the HTTP status line, so no client can reach a different conclusion depending on which it reads
+
+#### Scenario: A success is unaffected
+- **WHEN** an endpoint renders a `Success`
+- **THEN** the response carries the endpoint's declared success status and the standard success envelope
+
+### Requirement: The status SHALL be derived from ErrorKind through a single shared mapping
+
+The renderer SHALL select the status from a single shared mapping keyed by
+`ErrorKind`. An endpoint SHALL NOT hand-pick a status per failure, and the mapping
+SHALL NOT be keyed on any feature's concrete error type.
+
+The mapping SHALL be: `VALIDATION` → 422, `NOT_FOUND` → 404, `CONFLICT` → 409,
+`AUTHENTICATION` → 401, `AUTHORIZATION` → 403, `EXTERNAL_SERVICE` → 502,
+`INFRASTRUCTURE` → 500 when the error is not retryable and 503 when it is.
+
+#### Scenario: Each kind maps to its status
+- **WHEN** failures of each of the seven kinds are rendered
+- **THEN** they return 422, 404, 409, 401, 403, 502, and 500 or 503 respectively, from the shared mapping
+
+#### Scenario: An authentication failure is not answered as a validation failure
+- **WHEN** an endpoint renders a failure whose kind is `AUTHENTICATION` — invalid credentials, invalid token, expired token
+- **THEN** the HTTP status is 401, matching what the equivalent raised exception produces today, so converting the service to Result does not change the status a client sees
+
+#### Scenario: An authorization failure is distinguished from an authentication failure
+- **WHEN** an endpoint renders a failure whose kind is `AUTHORIZATION`
+- **THEN** the HTTP status is 403, and a client can distinguish it from the 401 an `AUTHENTICATION` failure produces
+
+#### Scenario: A retryable infrastructure failure signals retry
+- **WHEN** an infrastructure error declares itself retryable
+- **THEN** the response status is 503, and a non-retryable infrastructure error returns 500
+
+#### Scenario: A dead transaction is not advertised as retryable
+- **WHEN** a repository classifies a failed database write that has been rolled back
+- **THEN** the error it constructs is not retryable, so the client receives 500 and is not told to retry work that cannot succeed
+
+#### Scenario: Adding a feature error type does not touch the mapping
+- **WHEN** a feature adds new error types to its union
+- **THEN** the shared mapping is unchanged, because each new type declares one of the seven existing kinds
+
+### Requirement: Every endpoint SHALL emit the same error envelope shape
+
+A rendered failure SHALL use the project's standard error envelope, with the same
+fields in the same shape as the global exception handler produces. A client SHALL
+NOT be able to tell from the envelope whether a failure was rendered by an
+endpoint or by the handler.
+
+The error `code` in the envelope SHALL be the feature error type's class constant.
+It SHALL NOT be a string composed at the endpoint.
+
+#### Scenario: Rendered and handled failures look alike
+- **WHEN** the same logical failure is produced once by a rendered `Failure` and once by an escaping exception
+- **THEN** the two response bodies have the same envelope structure and field names
+
+#### Scenario: The code comes from the error type
+- **WHEN** a failure is rendered
+- **THEN** the envelope's error code is the value declared as a class constant on the error type, so it cannot differ between two endpoints rendering the same error
+
+#### Scenario: No endpoint composes its own error body
+- **WHEN** an endpoint needs to return a failure
+- **THEN** it calls the shared renderer, and does not construct an error dictionary or response object itself
+
+### Requirement: Rendering SHALL NOT require the endpoint to know the feature's error types
+
+The renderer SHALL accept any feature's `Result` and require no
+per-feature configuration, so adding a feature adds no renderer code.
+
+An endpoint SHALL be able to override the success status and supply a
+human-readable success message, but SHALL NOT be able to override the failure
+status, because that would reintroduce the per-endpoint status drift this
+requirement exists to remove.
+
+The parameter carrying the success status SHALL be named for what it is — a
+success status — and SHALL NOT be named `status_code`, which reads at the call
+site as though it governs the failure.
+
+#### Scenario: One renderer serves every feature
+- **WHEN** endpoints from different features render their own Results
+- **THEN** they call the same renderer with no feature-specific arguments
+
+#### Scenario: A success status is configurable
+- **WHEN** a creation endpoint renders a `Success`
+- **THEN** it can declare 201 as the success status while the failure statuses remain governed by the shared mapping
+
+#### Scenario: The success-status parameter is unambiguously named
+- **WHEN** a developer reads a `render_result(...)` call at an endpoint
+- **THEN** the parameter's name makes clear it applies only to the success path, so it is not misread as setting the failure status
+
+#### Scenario: A failure status is not overridable at the call site
+- **WHEN** an endpoint attempts to force a specific status for a failure
+- **THEN** the renderer offers no parameter to do so, and the status remains the one derived from the error's kind

--- a/openspec/changes/error-handling-foundation/specs/pattern-matching-standard/spec.md
+++ b/openspec/changes/error-handling-foundation/specs/pattern-matching-standard/spec.md
@@ -1,0 +1,100 @@
+## MODIFIED Requirements
+
+### Requirement: Pattern matching taxonomy is documented
+The project SHALL maintain a decision matrix in `.opencode/instructions/RESULT-PATTERN.md` that catalogs all pattern matching approaches used in the codebase and declares which to use in each scenario. The matrix SHALL distinguish the `Result` **container**, which is opened by narrowing, from the **error union** inside it, which is dispatched by `match`. Every duplicated copy of that document elsewhere in the repository SHALL state the same rule.
+
+#### Scenario: Decision matrix exists
+- **WHEN** a developer reads `.opencode/instructions/RESULT-PATTERN.md`
+- **THEN** they find a table mapping scenarios (e.g., "Opening a `<Feature>Result[T]`", "Dispatching on a feature error union", "Routing on enum") to the correct pattern (e.g., "`isinstance(result, Failure)`", "`match` + `assert_never`", "match/case on literals")
+
+#### Scenario: The matrix explains why, not only what
+- **WHEN** a developer reads the row for opening a `Result`
+- **THEN** it records that `match result: case Success(value)` does not narrow under the project's type checker, so the rule can be re-verified rather than taken on trust
+
+#### Scenario: Duplicated copies do not drift
+- **WHEN** a rule in `.opencode/instructions/RESULT-PATTERN.md` or `EXCEPTION-RULES.md` changes
+- **THEN** every other copy of that document in the repository is updated in the same change, and a copy stating a superseded rule is a defect
+
+### Requirement: Typed error hierarchy translation uses structural match/case
+Translating a typed error into a raising boundary's exception type SHALL use `match`/`case` with structural binding to extract fields, and SHALL close with `assert_never` where the source is a closed union.
+
+Such translation SHALL occur only where a boundary must raise — a FastAPI dependency, a WebSocket session, a Celery task, an MCP handler. It SHALL NOT occur on the HTTP response path, where a failure is rendered from its `kind` rather than converted into an exception.
+
+#### Scenario: AppError to APIException mapping
+- **WHEN** the shared translation function receives an error carrying a resource and identifier and the calling layer must raise
+- **THEN** it returns the corresponding exception with those fields extracted by structural binding, rather than by attribute access on a base type
+
+#### Scenario: A raising boundary translates structurally
+- **WHEN** an authentication dependency receives a typed failure it must reject the request for
+- **THEN** it matches the error union with structural binding, raises the corresponding exception carrying the bound fields, and closes the match with `assert_never`
+
+#### Scenario: The HTTP path does not translate
+- **WHEN** an endpoint receives a typed failure
+- **THEN** it renders the failure from its `kind` and does not convert it into an exception for the global handler
+
+#### Scenario: A new error type breaks stale translations
+- **WHEN** a member is added to a feature's error union
+- **THEN** every structural translation over that union fails type-checking until an arm is added
+
+### Requirement: isinstance+model_validate hybrid is replaced with match/case
+Where a value may arrive either as a model instance or as its serialised mapping — a graph state field that has round-tripped through a checkpointer — the pattern `x if isinstance(x, Model) else Model.model_validate(x)` SHALL be replaced with `match x: case Model(): ... case dict() as raw: Model.model_validate(raw)`.
+
+This is a genuinely dynamic boundary, not typed data. The `match` here is correct for the same reason the container `match` is not: the incoming value's type is unknown, so the class pattern is doing real work rather than failing to narrow an already-typed union.
+
+#### Scenario: LangGraph state failure handling
+- **WHEN** a service reads a failure value out of LangGraph state that may be a model instance or a mapping
+- **THEN** it uses `match failure: case FeatureError() as error: pass case dict() as raw: error = <ConcreteError>.model_validate(raw)`, rather than an `isinstance`/`model_validate` conditional expression
+
+#### Scenario: The deserialised value re-enters the closed union
+- **WHEN** a mapping from graph state is validated back into an error instance
+- **THEN** it is validated into a concrete member of the feature's union, so downstream exhaustive matches remain valid
+
+## REMOVED Requirements
+
+### Requirement: Service-layer Result unwrapping uses match/case
+
+**Reason**: The requirement is contradicted by the project's own type checker and by every line of code in the repository. Measured with `uv run ty check`, `match result: case Success(value)` performs **no narrowing** — `value` binds to the union of the success type and the error type, so the code that follows is unchecked in exactly the place the pattern was adopted to make it safe. `isinstance(result, Failure)` narrows correctly on both branches. The codebase already reflects this: 122 sites use `isinstance(result, Failure)` and **zero** match on `Success`/`Failure`. Three other governance artifacts — `openspec/config.yaml`, the `spec-gated` review instruction, and the `.ast-grep/rules/no-match-on-result` gate — already state the `isinstance` rule. This requirement was the sole dissenting artifact, and it was never implemented.
+
+**Migration**: Replaced by *"Service-layer Result unwrapping uses isinstance narrowing"* and *"Feature error unions are dispatched with exhaustive match/case"* below. No code changes: existing `isinstance(result, Failure)` unwrapping already satisfies the replacement. The two scenarios removed here described `AuthService.login()` and `DocumentCommandService.upload_document()` unwrapping with `match`; both are restated against the replacement requirement so the behaviour they described is not lost.
+
+## ADDED Requirements
+
+### Requirement: Service-layer Result unwrapping uses isinstance narrowing
+
+All code that unwraps a `returns.result.Result` SHALL use `isinstance(result, Failure)`. It SHALL NOT `match` on `Success`/`Failure`.
+
+After `isinstance(result, Failure)` the type checker SHALL narrow `result.failure()` to the feature's error union and `result.unwrap()` to the success type. Code SHALL rely on that narrowing rather than re-asserting the type.
+
+#### Scenario: Auth service login unwraps user lookup
+- **WHEN** `AuthService.login()` calls `self._user_repo.find_by_email(dto.email)`
+- **THEN** the result is opened with `if isinstance(result, Failure):`, and inside that branch `result.failure()` is typed as the users feature's error union
+
+#### Scenario: Document service upload unwraps document lookup
+- **WHEN** `DocumentCommandService.upload_document()` calls `self.repo.get_document_by_user_hash(...)`
+- **THEN** the result is opened with `isinstance(result, Failure)`, and the not-found case is distinguished by matching the narrowed error rather than by a guard on the container
+
+#### Scenario: The success value is narrowed too
+- **WHEN** control passes the `isinstance(result, Failure)` branch without returning
+- **THEN** `result.unwrap()` is typed as the success type, with no cast or assertion needed
+
+#### Scenario: Matching the container is rejected by the gates
+- **WHEN** code matches on `Success`/`Failure` in any form, including the bound forms `case Success(value):` and `case Failure(error):`
+- **THEN** the project's enforcement rule reports a violation
+
+### Requirement: Feature error unions are dispatched with exhaustive match/case
+
+`match`/`case` SHALL be used on a feature's closed error union, after the `Result` has been opened by narrowing. Such a match SHALL close with `case _ as unreachable: assert_never(unreachable)`.
+
+This is where `match` earns its place: over a closed union the type checker both narrows each arm and proves the set complete, so a new failure mode cannot be silently ignored. Over the `Result` container it does neither.
+
+#### Scenario: An exhaustive dispatch type-checks
+- **WHEN** a service matches every member of its feature's error union and closes with `assert_never`
+- **THEN** `uv run ty check src/` reports no diagnostic
+
+#### Scenario: A missing arm fails the type check
+- **WHEN** one member of the union has no arm
+- **THEN** `uv run ty check src/` reports `type-assertion-failure` and names the uncovered member as the inferred argument type
+
+#### Scenario: Arms are flat, never nested by inheritance
+- **WHEN** a match dispatches on error types
+- **THEN** no arm's type is a supertype of another arm's type, because a class pattern is `isinstance`-based and a broader arm would shadow a narrower one while still reporting the match exhaustive

--- a/openspec/changes/error-handling-foundation/specs/repository-transaction-safety/spec.md
+++ b/openspec/changes/error-handling-foundation/specs/repository-transaction-safety/spec.md
@@ -1,0 +1,136 @@
+## Purpose
+
+Guarantees that a repository which catches a database exception leaves the session
+usable, so that a failure a caller chooses not to propagate can never be followed
+by a successful commit of a partial write, and states what a repository owes when its
+backing store has no transaction to roll back.
+
+## ADDED Requirements
+
+### Requirement: A relational repository SHALL roll back before returning a failure from a caught database exception
+
+When a repository catches an exception raised by the SQLAlchemy driver or ORM after
+any statement has been sent on the request-scoped session, it SHALL roll back that
+session before returning `Failure`. The order SHALL be: classify the exception into
+the feature's error type, roll back, log, return.
+
+Rollback SHALL happen in the repository, not in the service and not in the request
+dependency, because the repository is the only layer that knows a statement was
+issued.
+
+#### Scenario: A flush failure leaves the session usable
+- **WHEN** a repository catches `IntegrityError` from a flush and returns its conflict error
+- **THEN** it has rolled back the session first, and a subsequent statement on that same session succeeds rather than raising `PendingRollbackError`
+
+#### Scenario: The rollback precedes the log line
+- **WHEN** a repository catches `SQLAlchemyError` and both rolls back and logs
+- **THEN** the rollback happens before the log call, so a logging failure cannot leave the session poisoned
+
+#### Scenario: A read-only failure needs no rollback
+- **WHEN** a repository catches an exception from a `SELECT` that issued no write
+- **THEN** it may return `Failure` without rolling back, and the requirement is satisfied by the session remaining usable
+
+### Requirement: A swallowed failure SHALL NOT be followed by a commit of partial work
+
+A caller that receives a `Failure` and neither propagates it nor aborts the unit
+of work SHALL NOT allow that request to reach a successful commit carrying the
+partial write that failed.
+
+This is the live defect the rollback closes. The request-scoped session commits on
+successful exit and rolls back only when an exception escapes —
+`get_postgres_db` at `src/app/connections/postgres.py:241` yields, then calls
+`await session.commit()`, with `except Exception: await session.rollback(); raise` as
+its only rollback path. A returned `Failure` is not an escaping exception. Where a
+service unwraps a `Failure` and continues — the webhooks service unwraps repository
+Results at 21 sites and calls no bridge; the dunning service does the same — no
+exception escapes, so the dependency's rollback path never runs, and `commit()`
+executes on a session whose transaction is already failed.
+
+The dependency cannot detect that condition: it sees no exception and has no access
+to the `Result`. Widening it is therefore not an alternative to this requirement;
+`shared-infrastructure-errors` states that constraint from the dependency's side.
+
+#### Scenario: A swallowed repository failure does not commit
+- **WHEN** a service receives a `Failure` from a write, logs it, and returns a success envelope to its caller
+- **THEN** the partial write from the failed statement is not committed, because the repository already rolled it back
+
+#### Scenario: A multi-step operation fails partway
+- **WHEN** the second of three writes in one request fails and the service abandons the operation
+- **THEN** the first write is not persisted, and the response does not report success for work that was rolled back
+
+#### Scenario: The failed statement's error does not resurface at commit
+- **WHEN** a request continues after a caught database exception and reaches the end of its dependency scope
+- **THEN** the commit does not raise a rollback-required error attributed to the earlier statement
+
+### Requirement: Every relational repository SHALL be covered by this rule uniformly
+
+All repositories that issue statements on the request-scoped SQLAlchemy session
+SHALL follow the same rollback contract. A repository that catches a database
+exception without rolling back SHALL be a rule violation detectable by the project's
+enforcement gates, not a matter of reviewer attention.
+
+Measured scope. There are **11 repository modules** holding 12 repository classes
+(`auth/repository.py` holds two). Of those:
+
+- **9 are relational** and carry 74 SQLAlchemy handlers between them — `audit`,
+  `credits/consumption_repository`, `credits/credit_repository`, `documents`,
+  `invoices`, `payments`, `plans`, `subscriptions`, `webhooks`. These are the modules
+  this requirement covers. None of them rolls back today; `session.rollback` has
+  never appeared under `src/app/features/` in the repository's history.
+- **`auth/repository.py` is a document-store repository**, not a relational one. It
+  catches `PyMongoError`, `DuplicateKeyError` and `RedisError` across 19 handlers and
+  issues no statement on the SQLAlchemy session. It is covered by the next
+  requirement instead.
+- **`users/repository.py` catches nothing**, so it has no handler to fix.
+
+The rule therefore applies to every existing `except` block in the 9 relational
+modules, not only to new code.
+
+Database exceptions are also caught in three places that are not repositories —
+`features/health/service.py` and the two agent tools
+`shared/langchain_layer/agents/tools/{retrieve_statute_section,search_legal_precedents}.py`.
+All three are read-only and issue no write, so the read-only scenario above already
+covers them and their absence from a repository-scoped gate is not a hole.
+
+#### Scenario: A new repository inherits the obligation
+- **WHEN** a relational repository is added with an `except SQLAlchemyError` block that returns `Failure` without rolling back
+- **THEN** the enforcement gate reports a violation
+
+#### Scenario: A migrated feature has no unrolled-back handler
+- **WHEN** the enforcement gate is run over a feature whose migration change is complete
+- **THEN** it reports zero database-exception handlers that return `Failure` without rolling back
+
+#### Scenario: A non-repository read-only catcher is not a violation
+- **WHEN** the gate encounters a health probe or an agent tool that catches `SQLAlchemyError` on a read and returns a status dict or an unavailable tool result
+- **THEN** no violation is reported, because no statement was written and the session remains usable
+
+### Requirement: A document-store repository SHALL classify its driver taxonomy and SHALL NOT be given a rollback
+
+A repository whose backing store has no request-scoped transaction SHALL classify
+its driver's exceptions into its feature's union and return `Failure`, and SHALL NOT
+be required to roll back. It SHALL NOT be exempted from classification on the grounds
+that the rollback rule does not reach it.
+
+`auth/repository.py` is the only instance. It holds `UserRepository` and
+`RefreshTokenRepository`, backed by MongoDB and Redis, with 13 Mongo handlers and 6
+Redis handlers and no SQLAlchemy usage. There is no session to poison, so the
+poisoned-commit defect cannot occur there — but its **7 `"DB_ERROR"` literals** are
+Mongo and Redis failures wearing a relational label, and they retire on the same
+terms as the other 49.
+
+Their retryability differs and SHALL be preserved. A failed relational transaction is
+dead and the correction sends it from 503 to 500. A Mongo or Redis outage is
+genuinely retryable, so those 7 sites SHALL keep a retryable classification and SHALL
+NOT be swept into the 503 → 500 correction.
+
+#### Scenario: A document-store failure is classified without a rollback
+- **WHEN** `UserRepository` catches `PyMongoError` from a write
+- **THEN** it classifies into the auth feature's union and returns `Failure`, and no rollback is attempted or required
+
+#### Scenario: A duplicate key becomes a conflict, not an infrastructure failure
+- **WHEN** `UserRepository` catches `DuplicateKeyError` on an insert
+- **THEN** it returns the union's conflict member with `ErrorKind.CONFLICT`, not an infrastructure error
+
+#### Scenario: The retryable classification survives the DB_ERROR correction
+- **WHEN** the 7 `"DB_ERROR"` literals in `auth/repository.py` are replaced by enum members
+- **THEN** their kind remains retryable infrastructure and their status remains 503, distinct from the relational sites that correct to 500

--- a/openspec/changes/error-handling-foundation/specs/result-layer-boundaries/spec.md
+++ b/openspec/changes/error-handling-foundation/specs/result-layer-boundaries/spec.md
@@ -1,0 +1,298 @@
+## Purpose
+
+Draws the line between code that returns typed failures and code that raises,
+and states what every exception-native layer owes at the point it hands a failure
+to domain code, so that no file in the repository is left without a rule.
+
+## ADDED Requirements
+
+### Requirement: The domain core SHALL be Result-typed regardless of transport
+
+Repository and service methods SHALL return `<Feature>Result[T]`. They SHALL NOT
+raise to signal an expected failure, and SHALL NOT vary their contract by which
+transport eventually consumes them — a WebSocket handler calling a service SHALL
+receive the same typed `Result` an HTTP router receives.
+
+The same obligation applies to a module under `src/app/shared/` that classifies a
+third-party exception on behalf of callers. Being cross-feature infrastructure
+rather than a feature changes which union it owns, not whether it returns one; see
+`shared-infrastructure-errors`.
+
+Railway-oriented programming is a property of the domain core, not of the
+transport.
+
+#### Scenario: A service returns the same Result to every caller
+- **WHEN** the same service method is called from an HTTP router and from a WebSocket session loop
+- **THEN** both receive `<Feature>Result[T]`, and the service contains no branch that depends on the caller's transport
+
+#### Scenario: An expected failure is returned, not raised
+- **WHEN** a repository finds no row for a lookup that has a not-found member in its union
+- **THEN** it returns `Failure(<Feature>NotFoundError(...))` and raises nothing
+
+### Requirement: A Result SHALL be opened with isinstance, and a match SHALL be reserved for the error union
+
+Code unwrapping a `Result` SHALL use `isinstance(result, Failure)`. It SHALL NOT
+`match` on `Success`/`Failure`.
+
+This is a measured constraint, not a preference. On this repository's `ty`,
+`match result: case Success(value)` binds `value` to the union of the success and
+error types — no narrowing occurs — while `isinstance(result, Failure)` followed
+by `.failure()` narrows correctly to the feature's error union, and `.unwrap()`
+narrows to the success type.
+
+`match` SHALL be used on the error union obtained after that narrowing, where it
+does narrow and where `assert_never` is meaningful.
+
+#### Scenario: isinstance narrows both sides
+- **WHEN** a service unwraps `SubscriptionResult[Subscription]` with `isinstance(result, Failure)`
+- **THEN** `result.failure()` is typed as `SubscriptionError` and `result.unwrap()` is typed as `Subscription`
+
+#### Scenario: Matching on the container is rejected
+- **WHEN** code is written as `match result: case Success(value): ... case Failure(error): ...`
+- **THEN** the enforcement rule reports a violation, because `ty` does not narrow through it and the bound values are the union of both sides
+
+#### Scenario: The narrowed error is matched exhaustively
+- **WHEN** a service needs different handling per failure mode
+- **THEN** it opens the `Result` with `isinstance`, then matches the narrowed error union and closes with `assert_never`
+
+### Requirement: try/except in domain code SHALL only wrap a call into code the project does not own
+
+A `try`/`except` block inside a repository or service SHALL wrap only a call into
+a third-party library — SQLAlchemy, httpx, redis-py, the Razorpay SDK, boto3, an
+LLM provider client. It SHALL NOT wrap a call to another repository or service
+method in this project, because those return a `Result` that is consumed by
+narrowing, not by catching.
+
+The `except` block SHALL classify the caught exception into a specific member of
+the feature's union. Classification SHALL remain explicit and readable at each
+site; it SHALL NOT be hidden behind a generic wrapper or context manager, because
+which library exception maps to which typed error is feature-specific knowledge.
+
+#### Scenario: A third-party call is wrapped
+- **WHEN** a repository calls `session.flush()`
+- **THEN** the call is inside a `try` whose `except IntegrityError` and `except SQLAlchemyError` blocks each classify into a named member of the feature's union
+
+#### Scenario: An owned call is not wrapped
+- **WHEN** a service calls its repository
+- **THEN** the call is not inside a `try`, and the returned `Result` is opened with `isinstance`
+
+#### Scenario: Classification stays at the site
+- **WHEN** two repositories both catch `IntegrityError`
+- **THEN** each maps it to its own feature's conflict error explicitly, and no shared helper performs the mapping on their behalf
+
+### Requirement: An error constructed inside an except block SHALL be logged at construction
+
+When a `FeatureError` is constructed inside an `except` block — something
+actually threw — it SHALL be logged before the `Failure` is returned.
+
+When a `FeatureError` is constructed from a plain check with no exception
+involved — a `None` from `scalar_one_or_none()`, a failed state-transition guard —
+it SHALL NOT be logged automatically. Some of these are ordinary control flow,
+and logging every one turns normal branching into incident noise.
+
+Where a mutation was flushed before the exception, the order SHALL be: classify,
+roll back, log, return.
+
+#### Scenario: An exception-derived failure is logged
+- **WHEN** a repository catches `SQLAlchemyError` and constructs its infrastructure error
+- **THEN** the error is logged inside the `except` block before `Failure` is returned
+
+#### Scenario: A check-derived failure is not logged automatically
+- **WHEN** a repository's `scalar_one_or_none()` returns `None` and a not-found error is constructed
+- **THEN** no log line is emitted by the repository, and whether that not-found is worth logging is the caller's decision
+
+#### Scenario: A not-found used as control flow stays silent
+- **WHEN** a service uses a not-found result to decide that this is a first upload rather than a duplicate
+- **THEN** the normal path emits no warning, because the failure is an expected branch and not an incident
+
+### Requirement: Every exception-native layer SHALL be named, classified, and own its adapter
+
+A layer that is exception-native in its own right SHALL stay exception-based, and
+SHALL be listed with an adapter contract stating where it converts to or from a
+typed `Result`.
+
+Every file that **constructs, catches, propagates, or renders an error** SHALL
+fall under exactly one classification. A file that does none of those — a DTO, a
+schema, an ORM model, a settings module, an enum, a pure helper — is outside this
+requirement and needs no classification; a rule for it would be a rule about
+nothing. The classification SHALL be:
+
+| Layer | Pattern | Adapter obligation |
+|---|---|---|
+| Repository, service (all features) | Result | is the domain core |
+| Shared third-party wrappers (`shared/services/`, `shared/crawler/`) | Result | classify the library exception and own a union; see `shared-infrastructure-errors` |
+| Provider adapters inside `shared/rag/` | Result at the provider boundary | the `_provider_failure` boundary classifies; the surrounding pipeline stays exception-native |
+| Optional-dependency guards (`except ImportError`) | capability flag | not error handling; sets an availability flag and owes no classification |
+| Pre-service policy guards in a router body (rate limit, quota) | exceptions | not error handling; a boolean policy answer, raised before the service is called |
+| HTTP router | renders Result | see `http-result-rendering` |
+| WebSocket session and transport loop | exceptions | converts service Results at the send boundary; close codes stay exceptions |
+| `kb_retry` tenacity boundary | exceptions | raises on exhaustion; the calling node converts to a state failure |
+| Razorpay client tenacity boundary | exceptions | the payments service converts its taxonomy into `PaymentError` |
+| Celery task bodies (`src/tasks/`) | exceptions | framework owns retry and dead-letter; a task converts Results it consumes, and a broad catch names why the failure is survivable |
+| Celery beat cron entries | exceptions | same as task bodies |
+| Generation adapter behind a circuit breaker (`app/api/generation_with_cb.py`) | Result at the provider boundary | names the provider families it converts; SHALL NOT catch `Exception` and relabel it as service-unavailable |
+| API version routers (`app/api/v1.py`, `v2.py`) | none | aggregate routers; construct, catch, propagate and render nothing, so no row's obligation applies |
+| Framework-contract raises (Pydantic validators, PEP 562 module `__getattr__`, `NotImplementedError` stubs) | builtin raise | not error handling; the framework, not project code, reads the raise — exempt from the union rules |
+| Seeders and data scripts (`src/database/seeders/`) | exceptions | operator-facing, no envelope; owes an accurate exit status and the identity of the step that failed |
+| Example code (`app/examples/`) | whichever row its subject falls under | holds no exemption of its own; satisfies the same gates as production code, because its purpose is to be copied |
+| FastAPI auth dependencies | exceptions | the only way to short-circuit a route; converts Results it consumes |
+| LangGraph nodes | error in state | a node returns a state update and never raises |
+| MCP tool handlers and middleware | dict envelope | FastMCP owns the protocol; converts Results it consumes |
+| Circuit breaker and idempotency locks (`connections/celery_reliability.py`) | exceptions | must be reachable by a dispatcher, see below |
+| Agent tool wrappers | protocol result | the tool protocol owns the shape |
+| Global exception handler (`middleware/global_exception_handler.py`) | registration dispatch | owns the envelope; dispatches framework types by `isinstance`, exempt from the union rules |
+| Request session dependency (`connections/postgres.py`) | exceptions | commits on clean exit, rolls back only on an escaping exception; never inspects a Result |
+| Connection factories (`connections/neo4j.py`, `postgres.py`, `crawl4ai.py`) | exceptions | startup and pool construction; consumed by the lifespan's named handlers |
+| Cache helpers (`utils/cache/`) | Result | classify a backend failure as a cache failure, not a database failure |
+| Error vocabulary (`utils/exceptions.py`, `utils/codes.py`, `shared/result/errors.py`) | declares types | handles nothing; frozen for the migration, see `feature-error-contract` |
+| Lifespan and unsupervised background tasks (`lifecycle/lifespan.py`) | exceptions | degradation boundary; names every family it survives, must log, never crash startup |
+| HTTP middleware and health probes (`middleware/{server_middleware,health_check,otel,api_versioning}.py`) | exceptions or status dict | the global handler owns the envelope |
+| SSE streaming | exceptions | post-flush failures have no envelope; must be logged |
+| Scripts and CLI | exceptions | operator-facing, no envelope required |
+| Alembic env and migration bodies | exceptions | out of the domain contract |
+
+An exception-native layer SHALL NOT be converted to Result merely for uniformity.
+It SHALL be converted only where the project owns the control flow.
+
+A construct that resembles error handling but classifies nothing SHALL NOT be
+brought into the contract, and SHALL NOT be reported as a violation by a gate.
+Four kinds exist in this codebase and each is listed above: an `except ImportError`
+that sets an availability flag; a pre-service policy guard; the dispatcher's
+`isinstance` chain; and a raise that satisfies a framework contract. A policy guard is
+the least obvious of the first three.
+`features/crawler/router.py` calls `check_rate_limit`, which returns
+`tuple[bool, dict]` — no `Result`, no exception caught — and raises
+`TooManyRequestsException` at three sites when the answer is `False`. That raise is
+a rejection of the request before any service runs, not the rendering of a failure a
+service produced, so the rule that routers render rather than raise does not reach
+it. `shared/services/rate_limiter.py`, which supplies the boolean, raises nothing
+and catches nothing at all.
+
+The fourth kind is distinguished by **who reads the raise**, not by the exception's
+type. `app/config/settings.py:473` and `app/api/strict_envelope.py:26` raise
+`ValueError` inside Pydantic validators, where `ValueError` *is* the signalling
+protocol — Pydantic catches it and produces `ValidationError`, and returning a
+`Result` there would make the field validate successfully. `src/database/__init__.py:37`
+raises `AttributeError` from a PEP 562 module `__getattr__`, which `hasattr` and
+`from … import` depend on. The same builtin raised in a service is read by project
+code and converts like any other. `shared-infrastructure-errors` enumerates the three
+sites and states the rule.
+
+#### Scenario: Every error-handling file is classified
+- **WHEN** a reviewer opens a file that constructs, catches, propagates, or renders an error
+- **THEN** exactly one row of the classification applies to it, and such a file matching no row is a gap to be closed before the change is complete
+
+#### Scenario: A file with no error handling needs no rule
+- **WHEN** a reviewer opens a DTO, schema, ORM model, settings module, or pure helper that neither constructs, catches, propagates, nor renders an error
+- **THEN** no row is expected to apply, and its absence from the classification is not a gap
+
+#### Scenario: A non-feature directory is classified by role
+- **WHEN** a reviewer opens a file under `connections/`, `lifecycle/`, `middleware/`, `shared/`, `utils/`, `app/api/`, `app/config/`, `app/examples/`, `src/database/` or `src/tasks/` that handles an error
+- **THEN** a row applies to it by the role it plays — domain classifier, dispatcher, session dependency, degradation boundary, vocabulary, framework contract, task body, script or exemplar — and not being under `features/` is not grounds for exemption
+
+#### Scenario: An excluded tree is not a coverage gap
+- **WHEN** a reviewer finds unclassified error handling under `src/mcp_core/` or `src/lynk/`
+- **THEN** it is not reported as a gap in this contract, because `src/mcp_core/` is excluded by the owner's decision and `src/lynk/` contains no Python — the exclusion is recorded as a non-goal rather than left as an implied omission
+
+#### Scenario: A framework-contract raise is not a violation
+- **WHEN** the gate encounters `raise ValueError` inside a Pydantic validator or `raise AttributeError` inside a module `__getattr__`
+- **THEN** no violation is reported, because the framework reads that raise as its signalling protocol and a `Result` in its place would be read as success
+
+#### Scenario: Example code holds no exemption of its own
+- **WHEN** the gates are run over a completed change and a file under `app/examples/` demonstrates a forbidden pattern
+- **THEN** it is reported and corrected on the same terms as production code, and no rule is given a path exclusion for that directory
+
+#### Scenario: A policy guard in a router is not a rendering violation
+- **WHEN** the gate encounters a router that raises a rate-limit or quota exception after a boolean check that returned `False`, before calling its service
+- **THEN** no violation is reported, because no `Result` was produced and no exception was caught — the guard rejected the request rather than rendering a failure
+
+#### Scenario: A session loop keeps raising
+- **WHEN** a WebSocket session must close the connection on a revoked session
+- **THEN** it raises its close-code exception rather than threading a `Result` up through the receive loop
+
+#### Scenario: A retry boundary is the adapter
+- **WHEN** a tenacity-wrapped call exhausts its attempts and raises
+- **THEN** the calling node or service catches it once and converts it into a typed failure, and the retry machinery itself is not reimplemented around Results
+
+#### Scenario: A layer that consumes a Result converts at its own edge
+- **WHEN** a Celery task, an auth dependency, or an MCP handler calls a service and receives a `Failure`
+- **THEN** it converts that failure into its own mechanism — a raise, a dict envelope, or a retry — at that call site
+
+### Requirement: An error family SHALL be reachable by the dispatcher that is expected to handle it
+
+Every custom exception family SHALL be rooted so that the dispatcher responsible
+for it can catch it. A family rooted at `RuntimeError` that is expected to be
+rendered as an HTTP response or dead-lettered by a Celery relay SHALL be
+re-rooted, or the dispatcher SHALL be widened to name it explicitly.
+
+This closes a live gap. Six families under `connections/` and `shared/` are rooted
+at `RuntimeError`, bare `Exception` or `ValueError`, and **five of the six are caught
+nowhere in the repository** — `CircuitBreakerOpenError`, `IdempotencyLockError`,
+`AgentMemoryError`, `CogneeSetupError` and `StateSchemaVersionError` each have raise
+sites and zero catch sites. None is reachable by the global exception handler's
+`APIException` branch, and none by the outbox relay's publish handler, which names
+only `CeleryError` and `PostgresError`. The one counter-example,
+`TransientExternalError`, is caught by name at four consuming nodes and is the shape
+to copy. The WebSocket router likewise catches only its own violation family while
+Starlette `WebSocketException` is raised alongside it from the same module. The full
+inventory and the per-directory obligations are in `shared-infrastructure-errors`.
+
+A dead-letter path SHALL either catch every family its publish step can raise, or
+be documented as partial. It SHALL NOT be described as total while naming a closed
+list of exception types.
+
+#### Scenario: An HTTP-facing family reaches the envelope
+- **WHEN** a request path raises a member of the circuit-breaker family
+- **THEN** the global exception handler renders it into the standard error envelope with a deliberate status, rather than falling through to the unhandled 500 branch
+
+#### Scenario: A task-facing family reaches the dead-letter path
+- **WHEN** a Celery-dispatched operation raises a member of a `RuntimeError`-rooted family during an outbox publish
+- **THEN** the publish handler's catch names that family, so the event is dead-lettered rather than escaping the handler and leaving the row unclaimed
+
+#### Scenario: A partial dead-letter path is described as partial
+- **WHEN** a dead-letter handler catches a closed list of exception types
+- **THEN** the requirement describing it does not claim it dead-letters on any failure, and the families it cannot catch are named
+
+#### Scenario: A handler catches every family its module raises
+- **WHEN** a module raises both its own violation family and a framework exception from the same code path
+- **THEN** the consuming handler catches both, and no raise site in that module is left unhandled by its own consumer
+
+### Requirement: Every enforcement rule SHALL be verified against both the form it forbids and the form it permits
+
+An enforcement rule introduced or changed by this work SHALL be accompanied by a
+fixture containing at least one example of the construct it forbids and one
+example of the nearest construct it permits. The rule SHALL be shown to flag the
+first and not the second before any violation count derived from it is relied on.
+
+A rule's message SHALL describe what the rule actually matches. Where a rule's
+coverage is narrower than its message, either the pattern or the message SHALL be
+corrected.
+
+This is not ceremony. The entire design rests on gates: a closed union is closed
+only because a rule says nothing may subclass the base elsewhere, and a flat
+sibling set is flat only because a rule says so — there is no type-checker
+backstop for either. An unverified gate is indistinguishable from no gate, while
+reading as coverage.
+
+The `no-match-on-result` rule demonstrates the failure. Its pattern matches only
+the argument-less `case Success()` / `case Failure()` form, so
+`case Success(value):` — the exact construct the superseded spec mandated and this
+work forbids — passes it unflagged, while its message asserts that match/case does
+not narrow `Result`. Its reported count of zero violations is therefore not
+evidence that the codebase is clean.
+
+#### Scenario: A rule is shown to flag what it forbids
+- **WHEN** the rewritten container-match rule is run against a fixture containing `case Success(value):` and `case Failure(error):`
+- **THEN** it reports a violation for each
+
+#### Scenario: A rule is shown not to flag what it permits
+- **WHEN** the same rule is run against a fixture containing an exhaustive `match` over a feature's error union with concrete-type arms and an `assert_never` close
+- **THEN** it reports no violation, because that construct is the one the design requires
+
+#### Scenario: A count from a corrected rule is re-measured, not carried forward
+- **WHEN** a rule's pattern is corrected so that its coverage widens
+- **THEN** the violation count is re-measured with the corrected rule, and the previous count is not cited as a baseline
+
+#### Scenario: A rule whose message overstates its coverage is corrected
+- **WHEN** a rule's message describes a construct its pattern cannot match
+- **THEN** either the pattern is widened to match it or the message is narrowed to what it does match, and the discrepancy is not left in place

--- a/openspec/changes/error-handling-foundation/specs/shared-infrastructure-errors/spec.md
+++ b/openspec/changes/error-handling-foundation/specs/shared-infrastructure-errors/spec.md
@@ -1,0 +1,572 @@
+## Purpose
+
+Extends the error contract to the non-feature directories that carry the machinery
+every feature's errors travel through — `connections/`, `lifecycle/`, `middleware/`,
+`shared/`, `utils/`, plus `app/api/`, `app/config/`, `app/examples/`, `src/database/`
+and `src/tasks/` — so that the request-scoped session, the global dispatcher, the
+shared third-party wrappers, the cache layer, the startup degradation boundary, the
+task bodies, the framework-contract raises and the code the project offers as an
+exemplar each have a stated rule rather than being covered only by implication.
+
+## ADDED Requirements
+
+### Requirement: A shared module that wraps a third-party service SHALL own an error union, not raise an APIException
+
+A module under `src/app/shared/` that catches a third-party library's exception on
+behalf of callers SHALL classify it into a typed error and return `Failure`, on the
+same terms a feature repository does. It SHALL NOT convert a caught library
+exception into a raised `APIException`.
+
+Ownership of a union is a property of the module that classifies the error, not of
+whether that module happens to live under `features/`. Such a module SHALL declare
+its own `errors.py` with its own `<Module>Code` StrEnum, its own flat sibling error
+types and its own closed union, exactly as `feature-error-contract` requires of a
+feature. It SHALL NOT import a feature's error types, and no feature SHALL import
+its codes.
+
+This is measured, not hypothetical. `src/app/shared/services/` is four modules —
+`storage.py` (boto3), `tavily.py` (httpx), `mailer.py`, `rate_limiter.py` — with
+**31 raises** of `APIException` subclasses (`ServiceUnavailableException` ×16,
+`ValidationException` ×9, `ExternalServiceException` ×6) and **20 catches, every
+one of a third-party type** (`BotoCoreError`, `ClientError`, `httpx.HTTPStatusError`,
+`httpx.TimeoutException`, `httpx.RequestError`). It uses no `Result` anywhere. It is
+the exact shape this work converts — a service that owns a third-party boundary —
+and it was outside the classification because it is not a feature. It is also not
+peripheral: `storage` is imported by `profile`, `invoices` and `documents` as well as
+the lifespan, and `rate_limiter` by `crawler`.
+
+`shared/crawler/` is the same shape at smaller scale — 9 sites classifying
+`RedisError`, `json.JSONDecodeError`, `httpx.HTTPError` and `PlaywrightError`.
+
+`shared/rag/` is **mixed and SHALL NOT be converted wholesale.** Of its roughly 48
+handlers, 17 catch bare `Exception` and 7 catch `ImportError` as optional-dependency
+guards, while the genuine provider classification is concentrated in a
+`_provider_failure` helper used at 4 sites alongside named catches of `DoclingError`,
+`genai_errors.APIError`, `GraphitiError` and `yaml.YAMLError`. Only the provider
+boundary owes a union. The pipeline around it stays exception-native, and an
+`except ImportError` that sets an availability flag is capability detection, not error
+handling, and owes no classification at all.
+
+#### Scenario: A shared third-party wrapper returns a typed failure
+- **WHEN** `shared/services/storage.py` catches `(BotoCoreError, ClientError)` from an S3 call
+- **THEN** it returns `Failure` carrying a member of its own closed union, and raises no `APIException`
+
+#### Scenario: An optional-dependency guard owes no union
+- **WHEN** a module catches `ImportError` to record that an optional backend is unavailable
+- **THEN** no error type is constructed and no union is required, because the handler reports a capability rather than a failure
+
+#### Scenario: A mixed subtree is converted at its provider boundary only
+- **WHEN** the rag pipeline's provider adapter catches a provider library's exception
+- **THEN** that boundary returns a typed failure, while the surrounding pipeline's own handlers are classified as exception-native rather than rewritten
+
+#### Scenario: A shared module owns its codes
+- **WHEN** the shared services module needs a code for an upload failure
+- **THEN** it declares that member in its own StrEnum, and no feature's `<Feature>Code` is imported to supply it
+
+#### Scenario: A feature consuming a shared module narrows rather than catches
+- **WHEN** a feature service calls a shared third-party wrapper
+- **THEN** the call is not inside a `try`, and the returned `Result` is opened with `isinstance`
+
+#### Scenario: A shared module is not exempted for being shared
+- **WHEN** a reviewer argues a module needs no union because it is cross-feature infrastructure
+- **THEN** the argument is rejected, because the module classifies third-party exceptions and therefore owns the classification
+
+### Requirement: The cache layer SHALL classify a cache-backend failure as a cache failure
+
+A failure of the cache backend SHALL be classified as a cache or infrastructure
+failure distinguishable from a relational-database failure. It SHALL NOT be
+reported to a caller as a database error, and its retryability SHALL reflect that a
+cache backend is retryable.
+
+A cache helper SHALL NOT catch bare `Exception` around its own logic and convert
+whatever it catches into a backend failure. A `TypeError` or `AttributeError` raised
+by the helper's own code is a defect in that helper, not a backend outage, and
+SHALL NOT be reported as one.
+
+This does not conflict with the degradation-boundary allowance in
+`typed-exception-handling`. A degradation boundary catches `Exception` and then
+*degrades* — returns a fallback, sets the dependency to `None`, re-enters its loop.
+The cache helpers catch `Exception` and *escalate*, converting it into a raise that
+becomes a 500. Catching broadly to keep serving is the endorsed pattern; catching
+broadly to relabel is not.
+
+Measured: `src/app/utils/cache/redis_func.py` raises `DatabaseException` at **27
+sites** through a `_build_database_exception()` helper at line 36, each paired with
+one of **27 `except Exception as exc`** handlers. `DatabaseException` carries
+`ErrorCode.DATABASE_ERROR` and `HTTP_500_INTERNAL_SERVER_ERROR`, so a Redis outage
+is currently reported as a non-retryable Postgres failure. The file also re-raises
+its own family first (`except DatabaseException: raise`) before the catch-all, which
+correctly avoids double-wrapping and SHALL be preserved in shape.
+
+The module's only importers are `utils/cache/__init__.py` and
+`examples/redis_examples.py`; it is reachable from no request path today. The
+misclassification is therefore a latent defect and a bad exemplar rather than a live
+production fault, and this requirement is scheduled accordingly — but the file is
+the documented cache pattern, so leaving it wrong teaches the wrong classification.
+
+#### Scenario: A backend outage is not a database error
+- **WHEN** a cache read fails because the Redis backend is unreachable
+- **THEN** the failure is classified as a retryable cache or infrastructure error, and the caller does not receive `DATABASE_ERROR`
+
+#### Scenario: A defect in the helper is not laundered into an outage
+- **WHEN** a cache helper's own code raises `TypeError` because a caller passed an unserialisable value
+- **THEN** that failure is not reported as a cache-backend failure, and the caller can tell a misuse from an outage
+
+#### Scenario: Broad catching to degrade is still permitted
+- **WHEN** a caller decides a cache read failure should fall through to the source of truth
+- **THEN** it may catch broadly and continue, because the endorsed degradation pattern is to keep serving — the rule forbids catching broadly in order to relabel a failure, not catching broadly in order to survive one
+
+#### Scenario: The own-family re-raise is preserved
+- **WHEN** a cache helper calls another helper in the same module that has already classified a failure
+- **THEN** the already-classified failure passes through unchanged rather than being wrapped a second time
+
+#### Scenario: The example is corrected with the pattern
+- **WHEN** the cache module's classification changes
+- **THEN** `examples/redis_examples.py`, its only caller, is updated in the same change, so the documented example never demonstrates the retired classification
+
+### Requirement: The request-scoped session dependency SHALL remain the only committer and SHALL NOT inspect Results
+
+`get_postgres_db` SHALL keep its present shape: yield, commit on clean exit, roll
+back only when an exception escapes, close in `finally`. It SHALL NOT be modified to
+inspect a returned `Result`, and it SHALL NOT be given a second rollback path
+intended to compensate for a repository that did not roll back.
+
+The dependency is the counterparty to `repository-transaction-safety` and explains
+why that capability places rollback in the repository. Measured at
+`src/app/connections/postgres.py:241`:
+
+```python
+async with session_local() as session:
+    try:
+        yield session
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        raise
+    finally:
+        await session.close()
+```
+
+A returned `Failure` is not an escaping exception. When a service swallows one, this
+`except` never fires and `await session.commit()` runs against a session whose
+transaction has already failed. The dependency cannot detect that condition — it
+sees no exception and has no access to the `Result` — which is why the repository
+must roll back and why widening the dependency is not an alternative.
+
+#### Scenario: A swallowed failure still reaches this commit
+- **WHEN** a service receives a `Failure` from a write and returns normally
+- **THEN** the dependency's `except` branch does not run and `commit()` is reached, confirming that the repository is the only layer that can prevent the poisoned commit
+
+#### Scenario: The dependency is not widened
+- **WHEN** an implementer proposes threading a `Result` or a failure flag into the session dependency
+- **THEN** the proposal is rejected, because it would couple a transport-agnostic dependency to the domain error type and duplicate a rollback the repository already owes
+
+#### Scenario: The escaping-exception path is unchanged
+- **WHEN** an unhandled exception escapes a route that used the session
+- **THEN** the dependency still rolls back and re-raises, and this work does not alter that behaviour
+
+### Requirement: The global exception handler's isinstance dispatch SHALL be exempt from the union rules
+
+`middleware/global_exception_handler.py` dispatches on framework exception types
+with an `isinstance` chain. That chain SHALL NOT be rewritten as a `match` over a
+closed union, SHALL NOT be required to satisfy the flat-sibling rule, and SHALL NOT
+be flagged by any rule this work introduces.
+
+The types it dispatches on — `APIException`, `RequestValidationError`,
+`StarletteHTTPException`, `Exception` — are framework-owned. Their inheritance is
+real, load-bearing, and outside the project's control: `APIException` derives from
+`HTTPException`, which is why the handler's registration is split the way it is. The
+file carries a long comment at lines 166–200 recording that
+`add_exception_handler(Exception, ...)` alone was insufficient, that Starlette routes
+the `Exception` key to a different middleware than every other key, that FastAPI
+pre-seeds `HTTPException` so the MRO walk resolved three classes early and the
+`APIException` branch never ran, and that Starlette's and FastAPI's `HTTPException`
+are different classes. That comment ends with an explicit instruction not to
+simplify the registration. This requirement makes that instruction a rule.
+
+The handler also contains **zero `except` blocks** — it is invoked by registration,
+not by catching. Any enforcement rule that locates error handling by matching
+`except` will not see the single most important error-handling file in the
+repository, and SHALL NOT be described as covering the dispatcher.
+
+#### Scenario: The dispatcher keeps its isinstance chain
+- **WHEN** the container-match rule and the exhaustive-union rule are run over the global exception handler
+- **THEN** neither reports a violation, because the handler dispatches framework types rather than a feature's closed union
+
+#### Scenario: The registration is not simplified
+- **WHEN** a change proposes collapsing `register_exception_handlers` to a single `Exception` registration
+- **THEN** the proposal is rejected with reference to the recorded reason, and the split registration is preserved
+
+#### Scenario: An except-based gate does not claim to cover the dispatcher
+- **WHEN** a rule that matches `except` clauses reports its coverage
+- **THEN** the global exception handler is named as outside that rule's reach, so a clean count is not read as the dispatcher having been checked
+
+### Requirement: The startup degradation boundary SHALL name every family it survives
+
+`lifecycle/lifespan.py` SHALL keep catching named exception types rather than being
+widened to bare `Exception`, and each handler SHALL log before continuing so a
+degraded start is visible.
+
+It is the reference implementation of the "widen the dispatcher" resolution offered
+by `result-layer-boundaries`' family-rooting requirement. Measured: **14 handlers**
+naming roughly twenty distinct types across the startup sequence — including
+`ExceptionGroup`, `redis.exceptions.RedisError`, `OperationalError`,
+`PlaywrightError`, neo4j's `ServiceUnavailable`, `ServiceUnavailableException`, and
+`CogneeDimensionMismatchError` — against exactly **one** `except Exception as exc`.
+Catching `CogneeDimensionMismatchError` by name is the correct handling of a family
+rooted outside the project's base: the dispatcher was widened to reach it rather
+than the family being left unreachable.
+
+A new startup step SHALL name the exceptions its own initialisation can raise. It
+SHALL NOT rely on the single existing catch-all, because a catch-all cannot
+distinguish an optional subsystem being absent from a required one being
+misconfigured.
+
+#### Scenario: A new startup step names its own failures
+- **WHEN** a subsystem is added to the lifespan sequence
+- **THEN** its initialisation is guarded by a handler naming the exception types it can raise, and it does not depend on the existing catch-all
+
+#### Scenario: A degraded start is logged, not silent
+- **WHEN** an optional subsystem fails to initialise and startup continues
+- **THEN** a log line records which subsystem degraded and why, and the application does not report a clean start
+
+#### Scenario: A required subsystem still fails the start
+- **WHEN** a subsystem the application cannot serve requests without fails to initialise
+- **THEN** startup fails rather than degrading, and the failure is distinguishable from an optional subsystem being unavailable
+
+### Requirement: An exception family rooted outside the project base SHALL be caught by name or re-rooted
+
+Every custom exception family declared under `connections/` or `shared/` and rooted
+at `RuntimeError`, `Exception` or `ValueError` SHALL either be re-rooted so an
+existing dispatcher catches it, or be named explicitly by every dispatcher on its
+propagation path. A family with no catch site anywhere SHALL be treated as a defect,
+not as a style choice.
+
+Measured across these directories — six such families, of which **one** is ever
+caught by name:
+
+| Family | Root | Declared at | Raises | Catch sites |
+|---|---|---|---|---|
+| `TransientExternalError` | `Exception` | `shared/langgraph_layer/kb_retry.py:80` | 2 | **4**, by name in `ingestion_kb/nodes.py` |
+| `CircuitBreakerOpenError` | `RuntimeError` | `connections/celery_reliability.py:69` | 2 | **none** |
+| `IdempotencyLockError` | `RuntimeError` | `connections/celery_reliability.py:436` | 1 | **none** |
+| `AgentMemoryError` (+3 subclasses) | `RuntimeError` | `shared/langchain_layer/agents/memory/agent_memory_service.py:32` | 2 | **none** |
+| `CogneeSetupError` (+1 subclass) | `RuntimeError` | `shared/langchain_layer/agents/memory/cognee_client.py:54` | 2 | **none** |
+| `StateSchemaVersionError` | `ValueError` | `shared/langgraph_layer/agent_saul/state.py:356` | 1 | **none** |
+
+`TransientExternalError` is the pattern to copy: declared at the retry boundary,
+caught by name at each consuming node. The five with no catch site propagate to
+whatever generic boundary happens to sit above them — the global handler's unhandled
+branch on a request path, `server_middleware.py`'s single bare `except Exception`, or
+nothing at all in a Celery worker, where the outbox relay's publish handler names
+only `CeleryError` and `PostgresError`.
+
+`connections/celery_registry.py` shows the other correct resolution. Its
+`TaskDispatchError` base is rooted at `CeleryError` and is never raised directly; its
+two concrete subclasses `UnregisteredTaskError` and `TaskPayloadValidationError` are
+each raised twice, and neither is caught by name anywhere. That is not a gap: the
+relay's `except (CeleryError, PostgresError)` reaches them through their root. A
+family SHALL be considered reachable when a dispatcher on its path catches any
+ancestor of it, and an abstract base that is never raised directly SHALL NOT be
+reported as an unused declaration.
+
+#### Scenario: A family with no catch site is closed
+- **WHEN** the audit finds a declared exception family with raise sites and no dispatcher on its path catching it or any of its ancestors
+- **THEN** either a dispatcher is widened to name it or the family is re-rooted under a base an existing dispatcher already catches
+
+#### Scenario: A family reachable through its root needs no dedicated catch
+- **WHEN** a family's base is rooted under a type an existing dispatcher already catches, and only its concrete subclasses are raised
+- **THEN** the family is treated as correctly wired, and the absence of a catch clause naming it is not a finding
+
+#### Scenario: An unraised abstract base is not a defect
+- **WHEN** a family's base class has zero raise sites because it exists only to root its concrete members
+- **THEN** it is left in place, and only a family whose concrete members are all unraised is reported as an unused declaration
+
+#### Scenario: A worker-path family reaches the worker's boundary
+- **WHEN** a `RuntimeError`-rooted family is raised inside a Celery-dispatched operation
+- **THEN** the task boundary names it, so the failure is retried or dead-lettered rather than escaping as an unclassified worker error
+
+#### Scenario: The retry-boundary pattern is the reference
+- **WHEN** a new family is declared at a boundary that wraps an external call
+- **THEN** it follows the `TransientExternalError` shape — declared at the boundary, caught by name at each consumer — rather than being declared and left uncaught
+
+### Requirement: Inheritance among the shared spine's exception families SHALL be ordered narrowest-first at every catch site
+
+Where a family in these directories keeps concrete-to-concrete inheritance, every
+handler that catches more than one of its members SHALL order them narrowest first.
+The shadowing hazard that motivates the flat-sibling rule for `match` applies
+identically to `except` clause ordering, which is also resolved by `isinstance` in
+source order.
+
+Measured chains inside these five directories, nine in total:
+`InvalidTokenException`, `ExpiredTokenException` and `InvalidRefreshTokenException`
+under `UnauthorizedException` (`utils/exceptions.py:245,255,262`);
+`UnregisteredTaskError` and `TaskPayloadValidationError` under `TaskDispatchError`
+(`connections/celery_registry.py:86,101`); `CogneeDimensionMismatchError` under
+`CogneeSetupError`; and `ConversationIdentityRequiredError`,
+`PartitionIdentityInvalidError` and `ConsolidationPreconditionError` under
+`AgentMemoryError`.
+
+These are exception families, not `FeatureError` unions, so `feature-error-contract`'s
+flat-sibling rule does not reach them and they are not required to flatten while
+they remain exception-based. A member that migrates into a feature's closed union
+SHALL flatten at that point.
+
+#### Scenario: A broader member does not shadow a narrower one
+- **WHEN** a handler catches both a family's base and one of its subclasses
+- **THEN** the subclass clause appears first, so the specific branch is reachable
+
+#### Scenario: A migrating member flattens
+- **WHEN** an authentication exception subclass is replaced by a member of the auth feature's closed error union
+- **THEN** the replacement is a flat sibling of the other members and inherits from no other concrete error type
+
+#### Scenario: An exception family is not forced to flatten prematurely
+- **WHEN** a family in these directories remains exception-based because its layer is exception-native
+- **THEN** its inheritance is permitted, and only its catch-site ordering is required
+
+### Requirement: A raise that satisfies a framework contract SHALL be exempt from the union rules
+
+Where a framework, the standard library or a protocol requires a specific builtin
+exception to be raised, that raise SHALL remain a raise of that builtin and SHALL NOT
+be converted into a `Result` or into a project error type. Such a site SHALL NOT be
+reported as a violation by any gate this change introduces.
+
+Three instances exist and they are the whole population:
+
+| Site | Raises | Contract |
+|---|---|---|
+| `app/config/settings.py:473` | `ValueError` | a Pydantic v2 validator signals failure with `ValueError`; Pydantic wraps it into `ValidationError`. Returning a `Result` would make the field validate successfully |
+| `src/database/__init__.py:37` | `AttributeError` | PEP 562 module `__getattr__` must raise `AttributeError` for an unknown name, or `hasattr` and `from … import` break |
+| `app/api/strict_envelope.py:26` | `ValueError` | envelope shape assertion inside a validator, same Pydantic contract |
+
+`src/tasks/pageindex_tasks.py:30` raises `NotImplementedError` for an unimplemented
+task body. It is not a framework contract but it is not error handling either — it is
+an unwritten function — and SHALL be treated the same way: left alone, and not
+counted as an unclassified raise.
+
+The distinguishing test is not the exception's type but whether the caller is the
+project or the framework. A `ValueError` raised inside a validator is read by
+Pydantic. A `ValueError` raised in a service is read by project code, and that one
+converts.
+
+#### Scenario: A settings validator keeps raising ValueError
+- **WHEN** a Pydantic field validator rejects a configuration value
+- **THEN** it raises `ValueError` and no gate reports it, because Pydantic converts that raise into the model's `ValidationError`
+
+#### Scenario: A module __getattr__ keeps raising AttributeError
+- **WHEN** `src/database/__init__.py` is asked for a name it does not export
+- **THEN** it raises `AttributeError`, because returning a `Result` would make `hasattr` report the attribute as present
+
+#### Scenario: An unimplemented task body is not an unclassified raise
+- **WHEN** the gate encounters `raise NotImplementedError` in a task stub
+- **THEN** no violation is reported, and the site is excluded from the count of raises awaiting classification
+
+#### Scenario: The same builtin in project code is not exempt
+- **WHEN** a service or repository raises `ValueError` for a domain condition
+- **THEN** the exemption does not apply, because the caller is project code, and the site converts to a typed failure like any other
+
+### Requirement: A deliberate degradation SHALL name the reason it degrades
+
+A handler that catches broadly in order to keep processing SHALL record, at the catch
+site, why the failure is survivable. A broad catch with no stated reason SHALL be a
+violation; a broad catch with one SHALL NOT.
+
+This requirement codifies a convention the repository already follows, rather than
+introducing one. Measured repo-wide and reconciled by two structurally different
+queries: **62 `# noqa: BLE001` sites, 55 of which carry a written reason** after the
+code. The reference degradation boundary this change already designates follows it —
+`lifecycle/lifespan.py:234` reads
+`except Exception as exc:  # noqa: BLE001 — optional dependency; app degrades without it`.
+So does `shared/crawler/processor.py:171,201` and
+`shared/langchain_layer/agents/tools/shell.py:200`, the latter naming two codes and
+then its reason. The rule is therefore already the practice at 55 of 62 sites; what is
+missing is that it is written down and gated.
+
+The **7 exceptions are the whole population** and they fall in exactly two places:
+
+| Site | Count | Note |
+|---|---|---|
+| `features/subscriptions/service.py:324,390,429,482` | 4 | the exemplar feature — these are closed by this change's section 5 regardless |
+| `src/tasks/billing_tasks.py:202,242,299` | 3 | the same file's `:134` carries *"one bad subscription must not kill the run"*, so the reason is known and simply not written at three of its four sites |
+
+A bare `# noqa: BLE001` is not a reason. It silences `BLE001` — the rule whose entire
+job is to ask why the catch is broad — and records nothing in its place, which makes
+it **worse** than an unsuppressed `except Exception:`, because the unsuppressed form
+still trips the gate and can be found. A suppression SHALL NOT be accepted in place of
+a reason.
+
+`src/tasks/` is exception-native — the framework owns retry and dead-lettering, and
+`result-layer-boundaries` classifies task bodies as such. Its 17 `except` clauses
+across 6 of its 10 modules divide into 2 documented degradations, 3 bare suppressions
+(above), and 12 with no suppression and no reason: `credit_tasks.py:35,102`,
+`document_tasks.py:56`, `billing_tasks.py:80`, and 8 in the `auth_email_tasks` pair.
+
+`auth_email_tasks.py` and `auth_email_tasks_typed.py` hold the same four handlers
+(2 `except ValueError`, 2 `except Exception`) at near-identical offsets — `:105,111,144,150`
+against `:107,113,150,156`. Whichever survives, the duplicate's handlers SHALL NOT be
+left as a second, divergent copy of the rule.
+
+One mechanism must be preserved because the linter already encodes this
+distinction: **`BLE001` does not fire on a blind `except` that re-raises.**
+`middleware/server_middleware.py:100` catches `Exception`, logs with `.exception()`,
+and ends in a bare `raise`, and needs no suppression for it. A handler that re-raises
+is not degrading — it is a logging pass-through — so a gate written for this
+requirement SHALL spare it on the same terms.
+
+#### Scenario: A documented broad catch is preserved
+- **WHEN** the gate encounters `except Exception as exc:  # noqa: BLE001 — optional dependency; app degrades without it`
+- **THEN** no violation is reported, because the reason the failure is survivable is recorded at the catch site
+
+#### Scenario: A bare suppression is not a reason
+- **WHEN** the gate encounters `except Exception as exc:  # noqa: BLE001` with no text after the code
+- **THEN** a violation is reported, because the suppression silenced the only rule that asks why the catch is broad without recording an answer
+
+#### Scenario: An undocumented broad catch is a violation
+- **WHEN** the gate encounters a bare `except Exception:` in a task body with no recorded reason and no re-raise
+- **THEN** a violation is reported, and it is closed either by naming the families the task survives or by recording why surviving everything is correct here
+
+#### Scenario: A logging pass-through is not a degradation
+- **WHEN** a handler catches `Exception`, logs it, and ends in a bare `raise`
+- **THEN** no violation is reported and no reason is owed, matching `BLE001`'s own behaviour — nothing was survived, so there is nothing to justify
+
+#### Scenario: A task converts a Result it consumes at its own edge
+- **WHEN** a task body calls a migrated service and receives a `Failure`
+- **THEN** it converts that failure into a retry, a dead-letter or a logged skip at that call site, and does not thread the `Result` further
+
+#### Scenario: The duplicated task module does not carry a divergent copy of the rule
+- **WHEN** the two `auth_email_tasks` modules are reconciled
+- **THEN** exactly one set of handlers remains, and no second copy of the same four handlers survives with different behaviour
+
+### Requirement: Example code SHALL NOT demonstrate a pattern the project forbids
+
+Code under `app/examples/` SHALL satisfy the same enforcement gates as production
+code. An example demonstrating a retired or forbidden pattern SHALL be corrected or
+deleted, not exempted, because an example's purpose is to be copied. The directory
+SHALL NOT hold a lint exemption for an error-handling rule.
+
+**The exemption is not implicit — it is written down.** `pyproject.toml`'s
+`[tool.ruff.lint.per-file-ignores]` gives `src/app/examples/*.py` a **25-rule** block,
+of which **8 are the error-handling rules this change is about**:
+
+| Ignored rule | What it permits |
+|---|---|
+| `BLE001` | blind `except Exception` |
+| `E722` | bare `except:` |
+| `B904` | `raise` inside `except` without `from` — loses the cause chain |
+| `TRY201` | `raise e` where a bare `raise` belongs |
+| `TRY300` | a `return` in `try` that belongs in `else` |
+| `TRY301` | `raise` inside `try`, caught by its own handler |
+| `TRY400` | `logger.error` in an `except` where `.exception()` belongs |
+| `S112` | `try`/`except`/`continue` — swallowing in a loop |
+
+This is why `uv run ruff check src/app/examples/` reports **"All checks passed!"** while
+`ast-grep scan` reports **4 `error`-level `no-raw-httpexception` violations** in the
+same directory: ruff was told to look away, and ast-grep has no per-path ignore
+configured, so it is the only gate still reporting. A green ruff run over this
+directory is not evidence about the code — it is evidence about the ignore list. Those
+8 entries SHALL be removed and the resulting findings fixed.
+
+`app/examples/rag_agent_advanced.py` carries a **second**, additional block —
+`ANN201, ARG001, ASYNC250, B007, BLE001, F821, PLC0415` — whose `BLE001` is already
+dead: that file's 12 handlers are all named, so nothing in it is blind. It SHALL be
+dropped as part of the same edit.
+
+The concrete violations, enumerated:
+
+| Site | Defect |
+|---|---|
+| `redis_examples.py:211,239,265,299` | `raise HTTPException(status_code=500, detail=…)` — the 4 live `no-raw-httpexception` errors; loses the `error_code`, the structured message and the `data` payload the global handler extracts |
+| `redis_examples.py:97,108,136,148,164,179,263,297` | 8 `except DatabaseException as e` — downstream of the cache misclassification this change corrects |
+| `redis_examples.py:209,237,323,353,386,417` | 6 `except Exception as e`, permitted only by the `BLE001` entry above |
+| `logger_usage_example.py:60` | `raise e` inside its own `except Exception as e` handler — `TRY201`'s target; a bare `raise` re-raises in place without adding the current frame |
+
+The 8 `except DatabaseException` catches SHALL be updated **in the same change** that
+reclassifies `utils/cache/redis_func.py`, because this file is one of that module's
+only two importers. Split across two changes, the example would catch an exception the
+cache no longer raises and silently stop handling anything.
+
+`app/examples/rag_agent_advanced.py` is the counter-example that keeps this rule from
+over-firing: 9 handlers catch `(OpenAIError, GoogleAPIError)` by name and 3 catch
+`EOFError`/`KeyboardInterrupt` for its CLI loop, which is the endorsed form. It needs
+no behavioural change, and a gate that flags it is wrong.
+
+#### Scenario: An example is held to the production gates
+- **WHEN** `ast-grep scan src/` and `uv run ruff check src/` are run over a completed change
+- **THEN** both report zero violations under `app/examples/`, and neither carries a path exclusion for an error-handling rule in that directory
+
+#### Scenario: The error-handling ignores are removed from the ignore list
+- **WHEN** the `per-file-ignores` entry for `src/app/examples/*.py` is edited
+- **THEN** `BLE001`, `E722`, `B904`, `TRY201`, `TRY300`, `TRY301`, `TRY400` and `S112` are absent from it, and the findings that appear as a result are fixed rather than re-suppressed
+
+#### Scenario: A green lint run over an exempted directory is not evidence
+- **WHEN** a reviewer cites a passing `ruff check` over `app/examples/` as proof the directory is clean
+- **THEN** the claim is rejected until the ignore entry is read, because 8 of the rules that would report were disabled for that path
+
+#### Scenario: The raw HTTPException raises are corrected, not exempted
+- **WHEN** the 4 `raise HTTPException(status_code=500, …)` sites in `redis_examples.py` are addressed
+- **THEN** each raises a typed exception or renders a classified failure, and the `no-raw-httpexception` rule reports zero violations there
+
+#### Scenario: The example's catches follow the cache reclassification
+- **WHEN** `utils/cache/redis_func.py` stops raising `DatabaseException` for a Redis failure
+- **THEN** the 8 `except DatabaseException` sites in `redis_examples.py` are updated in that same change, so the example does not catch an exception that is no longer raised
+
+#### Scenario: A correct example is left alone
+- **WHEN** the gate encounters handlers catching `(OpenAIError, GoogleAPIError)` by name
+- **THEN** no violation is reported, because naming the third-party families is the pattern this change endorses
+
+### Requirement: A generation adapter behind a circuit breaker SHALL classify by name, not relabel a broad catch
+
+A module that wraps a model-provider call behind a circuit breaker SHALL name the
+provider families it converts, and SHALL NOT catch `Exception` and relabel it as a
+service-unavailable condition.
+
+`app/api/generation_with_cb.py` is the single instance: `except Exception as e` at
+line 33 followed by `raise ServiceUnavailableException(msg) from e` at line 36. Every
+failure inside the guarded call — a provider timeout, a malformed response, a
+`TypeError` in the project's own callback — is reported to the caller as the upstream
+being unavailable. A breaker that trips on the project's own bug counts a local defect
+as an upstream outage, and the metric that is supposed to protect the upstream becomes
+unreadable.
+
+This is the escalation half of the degradation distinction: catching broadly to keep
+serving is endorsed, catching broadly to **relabel** is not. `shared/rag/`'s
+`_provider_failure` boundary is the shape to follow.
+
+The rest of `app/api/` — `v1.py`, `v2.py` and `__init__.py` — is version-router
+aggregation with no error handling and needs no rule, per `result-layer-boundaries`'s
+scenario for files that handle no errors.
+
+#### Scenario: A provider failure is named
+- **WHEN** the guarded generation call fails because the provider timed out or returned an error
+- **THEN** the adapter catches that provider's exception by name and classifies it as an external-service failure
+
+#### Scenario: A local defect is not reported as an upstream outage
+- **WHEN** a `TypeError` or `AttributeError` originating in project code is raised inside the guarded call
+- **THEN** it is not converted into a service-unavailable condition, and it does not count toward the circuit breaker's failure threshold
+
+#### Scenario: The version routers need no rule
+- **WHEN** a reviewer opens `app/api/v1.py` or `app/api/v2.py`
+- **THEN** no row and no requirement applies, because they aggregate routers and neither construct, catch, propagate nor render an error
+
+### Requirement: A seeder SHALL survive one failing seeder without reporting success
+
+The database seeder runner SHALL record which seeder failed and SHALL NOT report a
+successful seed when one of its steps raised. Its broad catch SHALL name the reason it
+continues, on the same terms as a task body.
+
+`src/database/seeders/run_seeders.py:81` holds the directory's only handler, an
+`except Exception as exc:` in the seeder loop. Its role is operator-facing script, so
+it owes no envelope — `result-layer-boundaries` classifies scripts that way — but it
+does owe an accurate exit status, because it is run by hand and by the CI migration
+step, and a seeder that fails silently produces a database that looks seeded.
+
+`src/database/base.py` and `src/database/schemas/` are ORM models and declare no error
+handling; they need no rule.
+
+#### Scenario: A failing seeder is named and the run does not report success
+- **WHEN** one seeder in the loop raises while the others succeed
+- **THEN** the failure is logged with the seeder's identity, and the runner's exit status reports failure rather than success
+
+#### Scenario: The ORM schema modules need no rule
+- **WHEN** a reviewer opens `src/database/base.py` or a module under `src/database/schemas/`
+- **THEN** no row and no requirement applies, because they declare tables and handle no errors

--- a/openspec/changes/error-handling-foundation/specs/typed-exception-handling/spec.md
+++ b/openspec/changes/error-handling-foundation/specs/typed-exception-handling/spec.md
@@ -1,0 +1,184 @@
+## MODIFIED Requirements
+
+### Requirement: Database operations SHALL catch asyncpg.exceptions.PostgresError
+
+All asyncpg operations SHALL catch `asyncpg.exceptions.PostgresError` or its subclasses instead of bare `except Exception`. Each catch site SHALL add `exc.add_note()` with the query, table, and operation context.
+
+Client-side errors (`asyncpg.InterfaceError`, `asyncpg.InternalClientError`) SHALL be caught separately when they indicate programming errors rather than database failures.
+
+Where database access is mediated by SQLAlchemy inside a repository, the catch SHALL name the SQLAlchemy exception the driver error is wrapped in — `IntegrityError` for constraint violations, `SQLAlchemyError` otherwise — because the asyncpg exception does not reach the repository unwrapped.
+
+A catch site inside a repository SHALL roll back the session and return `Failure` carrying a member of the feature's error union. It SHALL NOT raise. A catch site outside the domain core — a relay, a script, a graph node holding a raw connection — follows its own layer's convention.
+
+#### Scenario: Reconciliation fetch failure catches PostgresError
+- **WHEN** a reconciliation database query fails
+- **THEN** the code catches `asyncpg.exceptions.PostgresError`, adds a note with the user_id and query, and returns a failure result
+
+#### Scenario: Outbox publish failure catches PostgresError
+- **WHEN** an outbox event publish fails at the database level
+- **THEN** the code catches `asyncpg.exceptions.PostgresError`, adds a note with the event_id and event_type, and marks the event as failed
+
+#### Scenario: Unique violation is returned as a conflict, not raised
+- **WHEN** an INSERT/UPDATE in a repository violates a UNIQUE constraint
+- **THEN** the code catches SQLAlchemy's `IntegrityError`, adds a note with the constraint name, rolls back the session, and returns `Failure` carrying the feature's conflict error whose kind is `CONFLICT`
+
+#### Scenario: Connection failure catches ConnectionDoesNotExistError
+- **WHEN** a query fails because the connection was closed/pooled away
+- **THEN** the code catches `asyncpg.exceptions.ConnectionDoesNotExistError`, adds a note with the operation, and retries with a new connection
+
+#### Scenario: Deadlock detected catches DeadlockDetectedError
+- **WHEN** a query fails because of a deadlock
+- **THEN** the code catches `asyncpg.exceptions.DeadlockDetectedError`, adds a note with the query, and retries the transaction
+
+#### Scenario: Client misuse is returned as a non-retryable infrastructure failure
+- **WHEN** an asyncpg API is used incorrectly (closed connection, wrong call order) inside a repository
+- **THEN** the code catches `asyncpg.exceptions.InterfaceError`, adds a note with the operation, rolls back, and returns `Failure` carrying an infrastructure error that declares itself **not** retryable, because a programming error does not become correct on a second attempt
+
+#### Scenario: A rolled-back write is not advertised as retryable
+- **WHEN** a repository returns a failure for a write whose transaction has been rolled back
+- **THEN** the error's retryable constant is false, so the boundary renders 500 rather than telling the client to retry a transaction that cannot succeed
+
+### Requirement: Agent tools SHALL catch OS-level and library-specific exceptions
+
+Agent tool operations SHALL catch specific exceptions instead of bare `except Exception`:
+- `OSError` (and subclasses `FileNotFoundError`, `PermissionError`) for filesystem operations
+- `redis.exceptions.RedisError` for Redis operations
+- `langchain_core.exceptions.LangChainException` for LLM operations
+- `subprocess.SubprocessError` for subprocess execution failures
+
+Each catch site SHALL add `exc.add_note()` with the command, path, or operation context.
+
+The tool boundary returns the normalised `ToolResult` envelope, whose `error` is a
+string because the consumer is a language model rather than a type checker. That
+string SHALL be derived from a typed error's code and message, not composed
+free-form at the catch site, so the same underlying failure reads identically from
+every tool. A dependency that is absent or unreachable SHALL use the envelope's
+unavailable form rather than its failure form, because an agent can act on
+unavailability and cannot act on "the tool is broken".
+
+#### Scenario: Shell command failure catches OSError
+- **WHEN** a shell command execution fails due to an OS error
+- **THEN** the code catches `OSError`, adds a note with the command and working directory, and returns a `ToolResult.fail(...)` result
+
+#### Scenario: File not found catches FileNotFoundError
+- **WHEN** a file read operation fails because the file doesn't exist
+- **THEN** the code catches `FileNotFoundError`, adds a note with the file path, and returns a `ToolResult.fail(...)` result
+
+#### Scenario: Permission denied catches PermissionError
+- **WHEN** a file or directory operation fails because of insufficient permissions
+- **THEN** the code catches `PermissionError`, adds a note with the path and required permission, and returns a `ToolResult.fail(...)` result
+
+#### Scenario: Redis cache failure catches RedisError
+- **WHEN** a tool's Redis cache operation fails
+- **THEN** the code catches `redis.exceptions.RedisError`, adds a note with the key and operation, and continues without cache
+
+#### Scenario: LLM call failure catches LangChainException
+- **WHEN** a tool's LLM call fails
+- **THEN** the code catches `langchain_core.exceptions.LangChainException`, adds a note with the model and operation, and returns a `ToolResult.fail(...)` result
+
+#### Scenario: Subprocess failure catches SubprocessError
+- **WHEN** a subprocess spawned by a tool fails
+- **THEN** the code catches `subprocess.SubprocessError`, adds a note with the command and return code, and returns a `ToolResult.fail(...)` result
+
+#### Scenario: An unconfigured dependency is reported as unavailable
+- **WHEN** a tool's optional dependency is not configured or not reachable
+- **THEN** the tool returns the envelope's unavailable form carrying the reason, and does not report a generic failure
+
+#### Scenario: A typed failure crossing into a tool keeps its code
+- **WHEN** a tool calls a Result-typed service and receives a `Failure`
+- **THEN** the envelope's error string carries that error's declared code, so the same failure is not described two different ways by two different tools
+
+### Requirement: Degradation boundaries SHALL keep except Exception with add_note
+
+The following locations SHALL keep `except Exception` because they are genuine degradation boundaries where:
+1. The exception types are unknown at catch time (optional dependencies with opaque internals)
+2. Too many exception types from multiple libraries could be thrown in a single block
+3. The operation MUST succeed or degrade gracefully — crashing is never acceptable
+
+Each of these sites SHALL add `exc.add_note()` with context and SHALL have a `# noqa: BLE001` comment with an explanatory reason.
+
+A handler SHALL NOT be documented as catching every failure while its `except` clause names a closed list of exception types. Where a handler is deliberately partial, the requirement describing it SHALL say so and SHALL name what escapes.
+
+#### Scenario: Optional dependency startup failure degrades gracefully
+- **WHEN** an optional dependency (Neo4j, Graphiti, Crawl4AI, object storage) fails to initialize during app startup
+- **THEN** the code catches `Exception`, adds a note with the dependency name and error details, sets the dependency to `None`, and continues startup
+
+#### Scenario: LangGraph node failure returns fallback state
+- **WHEN** a LangGraph node encounters an exception from an LLM, database, or external service
+- **THEN** the code catches `Exception`, adds a note with the node name and operation, and returns a fallback state dict without crashing the graph
+
+#### Scenario: OTEL instrumentation failure logs warning
+- **WHEN** an OTEL instrumentor fails to register
+- **THEN** the code catches `Exception`, adds a note with the instrumentor name, logs a warning, and continues without that instrumentor
+
+#### Scenario: OTEL provider shutdown failure logs warning
+- **WHEN** an OTEL provider fails to flush or shutdown
+- **THEN** the code catches `Exception`, adds a note with the provider name, logs a warning, and continues shutdown
+
+#### Scenario: The outbox scan and listen loops degrade on any failure
+- **WHEN** the outbox relay's scan pass or its long-running listener raises for any reason
+- **THEN** the code catches `Exception`, adds a note, logs, and skips or re-enters the loop, because a relay that dies leaves every pending event unpublished
+
+#### Scenario: The outbox publish step is a partial handler, not a total one
+- **WHEN** the outbox relay's publish step raises an exception outside the families it names
+- **THEN** the event is **not** dead-lettered and the exception escapes to the surrounding loop, and this partiality is stated rather than described as dead-lettering on any failure
+
+#### Scenario: Reranker model load failure falls back to default
+- **WHEN** a CrossEncoder model fails to load (OSError, ValueError, RuntimeError from torch/transformers)
+- **THEN** the code catches `Exception`, adds a note with the model name, loads the fallback model, and continues
+
+#### Scenario: Reranker inference failure returns unranked results
+- **WHEN** CrossEncoder reranking fails at inference time
+- **THEN** the code catches `Exception`, adds a note with the model name and chunk count, returns chunks without reranking, and logs a warning
+
+#### Scenario: Cognee recall failure returns empty list
+- **WHEN** `cognee.recall()` fails for any reason (ad-hoc exceptions outside CogneeApiError hierarchy)
+- **THEN** the code catches `Exception`, adds a note with the query and user_id, returns an empty list, and logs the failure
+
+## ADDED Requirements
+
+### Requirement: A repository SHALL NOT convert a caught third-party exception into a raise
+
+A `try`/`except` around a third-party call inside a repository or service SHALL
+classify the exception into a member of the feature's error union and return
+`Failure`. It SHALL NOT re-raise, and SHALL NOT translate the exception into an
+`APIException` subclass for the global handler to render.
+
+This supersedes the retired bridge-and-raise pattern. Translation into an
+exception type happens only at a boundary that must raise, and that boundary is
+named in the layer classification, not in a repository.
+
+#### Scenario: A caught library exception becomes a Failure
+- **WHEN** a repository catches an exception from a third-party client
+- **THEN** it returns `Failure` carrying a typed error, and the function has no `raise` statement in that handler
+
+#### Scenario: The retired raise pattern is rejected
+- **WHEN** code raises the result of translating a typed error into an exception from inside a repository or service
+- **THEN** the project's enforcement rule reports a violation
+
+#### Scenario: A raising boundary is still allowed to translate
+- **WHEN** a FastAPI dependency or a WebSocket session receives a typed failure
+- **THEN** it may translate and raise, because its layer is classified as exception-native
+
+### Requirement: A custom exception family SHALL be rooted where its dispatcher can catch it
+
+Every custom exception family SHALL be rooted so the handler responsible for it
+catches it. A family rooted at a bare builtin — `RuntimeError`, `ValueError` — that
+is expected to be rendered as an HTTP response or dead-lettered by a relay SHALL be
+re-rooted under the project's own base, or its dispatcher SHALL name it explicitly.
+
+Introducing a new exception family without naming the dispatcher that catches it
+SHALL be a rule violation, because an uncaught family surfaces as an unhandled 500
+or a silently abandoned queue row rather than as a diagnosable error.
+
+#### Scenario: A RuntimeError-rooted family is unreachable today
+- **WHEN** a circuit-breaker or agent-memory exception reaches the global exception handler
+- **THEN** it is not matched by the handler's project-base branch and falls through to the unhandled path, and this change re-roots the family or widens the branch to name it
+
+#### Scenario: A new family declares its dispatcher
+- **WHEN** a new exception family is introduced
+- **THEN** the handler that catches it is identified, and a family with no identified handler is a violation
+
+#### Scenario: A module's own consumer catches everything the module raises
+- **WHEN** a module raises both its own family and a framework exception from the same code path
+- **THEN** its consuming handler catches both, so no raise site in that module is unhandled by its own caller

--- a/openspec/changes/error-handling-foundation/tasks.md
+++ b/openspec/changes/error-handling-foundation/tasks.md
@@ -218,6 +218,9 @@ the exemplar are what every conversion is measured against.
 - [ ] 12.4 Publish the corrected conversion order, 14 entries: `audit` → `crawler` → `users` → `ingestion` → `dunning` → `profile` → `plans` → `invoices` → `payments` → `webhooks` → `agent_saul` → `credits` → `documents` → `auth`
 - [ ] 12.5 Write the **definition of complete** as the measurable zeros in section 17, and put it in `proposal.md`, so "complete migration" is a gate rather than a feeling
 
+- [ ] 12.6 Adopt the **union rule** for `tasks.md` merges and record it in `HANDOFF.md` §7: this file exists in five divergent branch copies whose tick counts differ against the same task list (measured 2026-09-01: 26 / 36 / 44 / 49 / 97 done). At every merge conflict on `tasks.md`, take the **union** of `- [x]` lines and the **superset** of sections — never one side wholesale.
+  > **Why:** taking one side wholesale is how Section 9's sixteen tasks were lost once already. The five PR branches forked from one commit (`58422c1`) and each committed its own copy, so no branch holds the union: PR E is missing tasks 3.2–3.11 (PR B's gates) and 5.1–5.8 (PR C's exemplar) even though it has the highest count. A tick is a claim about the repository, not about a branch.
+
 ## 13. Phase 1a — `shared/services/` (blocks `crawler`, `profile`, `invoices`)
 
 - [ ] 13.1 Convert `shared/services/storage.py` (21 raises) to a per-module union returning `Result`

--- a/openspec/changes/error-handling-foundation/tasks.md
+++ b/openspec/changes/error-handling-foundation/tasks.md
@@ -189,3 +189,92 @@ rollback across seventeen changes leaves the defect open for the duration.
 - [ ] 11.5 Record that **18** features exist, not 17: `subscriptions` migrates here as the exemplar and `chat` needs no change at all (`__init__.py` and `model.py`, zero raises, zero `except` clauses). Phase 2 is therefore 16 changes — 18 = 1 + 16 + 1 — and two deferred changes follow: `shared/crawler/` alongside `crawler`, and `shared/rag/`'s provider boundary alongside `documents`. `utils/cache/` is **not** deferred; it is task 7.5 here
 - [ ] 11.6 Carry the per-feature exit criteria into each feature change's tasks as its own checklist
 - [ ] 11.7 Carry all three Method notes into each feature change's review step: (1) enumerate a population by a second, structurally different query before a count becomes a claim; (2) `ls` the paths a plan says it will create and match the probe to the edge kind — `rg` cannot see symbol imports, `python -c "import x"` cannot see `TYPE_CHECKING` ones; (3) before citing a gate's zero, read its exclusion list
+
+---
+
+# Complete repo migration (sections 12–17)
+
+Locked decision #1 scoped this change to *"Core converted + every boundary
+classified"*. The owner has since asked for a **complete repo migration**, and
+sections 12–17 are what that adds.
+
+Decision #4 — *"Foundation + one change per feature"* — still governs **shape**:
+every conversion below is its own openspec change, authored and landed
+separately. These sections are the **program** that enumerates, orders and gates
+those changes, so the whole migration lives in one plan instead of fourteen
+unwritten ones. A task here is done when the change it names is authored and
+landed, not when someone has read it.
+
+Sections 1–11 must be complete before section 15 starts: the spine, the gates and
+the exemplar are what every conversion is measured against.
+
+## 12. Scope change — record it before acting on it
+
+- [ ] 12.1 Rewrite `proposal.md`'s **Out of scope** entry for "The other 16 features" as an in-scope, enumerated follow-on program naming all 14 conversions, so the proposal stops reading as an exclusion. Keep the sentence that each feature gets its own change — decision #4 is unchanged; only the open-endedness is
+- [ ] 12.2 Correct the feature arithmetic that task 11.5 recorded. Measured 2026-09-01: **18 = 1 exemplar + 14 conversions + 2 no-ops + 1 classify-only**, not `18 = 1 + 16 + 1`
+  > **Why:** `features/search/` is a **tombstone** — `__init__.py` is a docstring plus `__all__: list[str] = []` and nothing else; step 10 of `documents-unified-schema` deleted its models, repository, router, DTOs, constants and Celery ingest path. It has no code to convert, and task 11.4 currently schedules it **first**. `features/chat/` is likewise `__init__.py` + `model.py` with zero raises.
+- [ ] 12.3 Reclassify `health` from *conversion* to *classify-only* and remove it from 11.4's order, where it currently sits 13th
+  > **Why:** `features/health/service.py` is 405 lines that raise nothing and return no `Result`. Failure is a `"status": "unhealthy"` field on the response body, and `get_health` sets its own 200/503. `_check_graphiti` reports `not_configured` **without** touching overall status, precisely so a deployment without graph memory does not begin answering 503 from a mounted endpoint. A `Failure` rendered through `render_result` would override that on the `STATUS_BY_KIND` path. Converting it is a regression, not progress. It belongs with the exception-native layers: probe shape, degrades to data, gated not rewritten.
+- [ ] 12.4 Publish the corrected conversion order, 14 entries: `audit` → `crawler` → `users` → `ingestion` → `dunning` → `profile` → `plans` → `invoices` → `payments` → `webhooks` → `agent_saul` → `credits` → `documents` → `auth`
+- [ ] 12.5 Write the **definition of complete** as the measurable zeros in section 17, and put it in `proposal.md`, so "complete migration" is a gate rather than a feeling
+
+## 13. Phase 1a — `shared/services/` (blocks `crawler`, `profile`, `invoices`)
+
+- [ ] 13.1 Convert `shared/services/storage.py` (21 raises) to a per-module union returning `Result`
+  > **Method:** 17 of the 21 are `ServiceUnavailableException`, which keeps its 503, so this conversion has **no observable status break** — confirmed in task 11.3. `storage` is imported by `profile`, `invoices` and `documents`, so it gates three conversions, not one.
+- [ ] 13.2 Convert `shared/services/tavily.py` (8 raises); keep the 4 pre-flight argument guards as raises or reclassify them as `VALIDATION`, and treat only the other 4 as third-party classification
+- [ ] 13.3 Convert `shared/services/mailer.py` (2 raises). No importer outside its own package, so it blocks nothing and can land in any order within this section
+- [ ] 13.4 Confirm `shared/services/rate_limiter.py` stays excluded — **re-verified 2026-09-01: zero `raise`, zero `except` in the module.** It degrades by returning `(True, {})` when Redis is absent, so there is no error to classify
+- [ ] 13.5 Gate: `crawler`'s change must not merge before 13.1–13.3 land
+  > **Why (verified):** `features/crawler/service.py:18` reads `from app.shared.services import RateLimiter, RateLimitScope, get_rate_limiter, search` — `search` is re-exported from `tavily.py`. The dependency is on `tavily`, **not** `rate_limiter`, exactly as task 11.1 recorded. `rg` on the module name cannot see this edge; it is a symbol import through a package `__init__`.
+
+## 14. The two deferred shared boundaries
+
+- [ ] 14.1 Convert `shared/crawler/` (9 sites) in the same change as the `crawler` feature — a split leaves the feature rendering a `Result` over a layer that still raises
+- [ ] 14.2 Convert only `shared/rag/`'s `_provider_failure` boundary, in the same change as `documents`. Leave its 7 `ImportError` guards alone: they are capability detection, not error handling, and a `Result` there would report a missing optional dependency as a request failure
+- [ ] 14.3 Re-confirm that `shared/langchain_layer/` and `shared/langgraph_layer/` node bodies stay **classified, not converted**, beyond the family re-rooting already done in section 6 — and that completing the migration does not silently promote them into scope
+- [ ] 14.4 Classify the remaining `shared/` subpackages explicitly so none is left undefined: `agents`, `circuit_breaker`, `otel`, `otel_integrations.py`, `outbox`. Each gets a row in the layer table or a written exemption
+
+## 15. The 14 feature conversions (one openspec change each)
+
+Each change carries the per-feature exit criteria from task 11.6 and all three
+Method notes from 11.7. The notes below are what is *specific* to each feature —
+its measured surface and the hazard that will bite whoever takes it.
+
+- [ ] 15.1 `audit` — 2 modules (`model.py`, `repository.py`), 9 `Result` sites, 0 raises. No router, no service. Smallest real conversion, so it lands first and becomes the **second exemplar** the rest are diffed against
+- [ ] 15.2 `crawler` — 5 modules, 2 raises. **Blocked by 13.5.** Its router is mounted in neither `api/v1.py` nor `api/v2.py`, so its endpoints cannot be verified end to end; the change must say so rather than claim a green path
+- [ ] 15.3 `users` — 5 modules, 6 raises, 3 `Result`. Catches nothing today, so the rollback requirement has no work here
+- [ ] 15.4 `ingestion` — 4 modules, 1 raise. Also unmounted in both API versions; same verification caveat as `crawler`
+- [ ] 15.5 `dunning` — 4 modules, 1 raise. `dunning/service.py` is one of the two measured **`Failure`-swallow** sites, so the rollback fix changes behaviour here; expect tests that encoded the silent commit to fail
+- [ ] 15.6 `profile` — 3 modules, 9 raises, 0 `Result`. **Blocked by 13.1** (imports `storage`)
+- [ ] 15.7 `plans` — 6 modules, 6 raises, 23 `Result`. **Lowest-risk conversion**: its repository is the only one that already used the `ErrorCode` enum in structurally identical `except SQLAlchemyError` blocks, so it is the closest thing to a pre-migrated feature
+- [ ] 15.8 `invoices` — 13 modules, 13 raises, 27 `Result`, **own `exceptions.py`**. Blocked by 13.1. Its old exception classes die in this change; no dual system survives it
+- [ ] 15.9 `payments` — `clients/` subpackage, 12 raises, 25 `Result`, **own `exceptions.py`**. The provider clients are a third-party adapter boundary — classify by name, do not relabel
+- [ ] 15.10 `webhooks` — 8 modules, 13 raises, 18 `Result`, **own `exceptions.py`**. The **21 unwraps with zero bridge calls** make this the worst swallow site in the repo and the first place to look when the rollback fix surfaces behaviour changes
+- [ ] 15.11 `agent_saul` — 4 modules, 4 raises, 0 `Result`. Its `StateSchemaVersionError` was re-rooted in task 6.7; the conversion must not re-open it
+- [ ] 15.12 `credits` — plural-subpackage layout (`dto/`, `models/`, `repositories/`, `routers/`, `services/`), 8 raises, 40 `Result`, **own `exceptions.py`**. The layout differs from every other feature, so the exemplar's file-for-file diff does not transfer
+- [ ] 15.13 `documents` — 15 modules, 7 raises, 38 `Result`. **Largest surface.** Carries `shared/rag/`'s `_provider_failure` boundary (14.2) in the same change, and absorbed everything `search` used to hold
+- [ ] 15.14 `auth` — 9 modules, 52 raises, 52 `Result`. **Scheduled last, and where the design was weakest.** Its 16 `UnauthorizedException` raises are why `ErrorKind` ships with `AUTHENTICATION` (401) and `AUTHORIZATION` (403); five members would have rendered a failed login as 422. It is a document store, so **no rollback is added** — Beanie/Mongo has no session here. Its 7 `DATABASE_ERROR` sites stay `retryable` at 503 (task 7.2) and a sweep must not collapse them into the relational half
+- [ ] 15.15 Classify `health` under the exception-native contract instead of converting it, per 12.3, and add a test pinning that `get_health` still returns its own 200/503 and that a missing optional backend does not force 503
+- [ ] 15.16 Record `chat` and `search` as requiring no change, with the reason, so a later coverage audit does not read two untouched packages as a gap
+
+## 16. Retire the old hierarchy (only possible once 15.x is complete)
+
+- [ ] 16.1 Delete each feature's own `exceptions.py` in that feature's change — 4 exist: `credits`, `invoices`, `payments`, `webhooks`. A feature that keeps both is a dual system, which the design forbids
+- [ ] 16.2 Drive `no-raise-app-error-mapper` from 34 violations to **0**, retiring them per feature rather than in a sweep
+- [ ] 16.3 Drive the 118 off-enum `code` literals (68 distinct codes against an 18-member enum) to **0**
+- [ ] 16.4 Drive the 123 `*AppError` construction sites (72 of them `InfrastructureAppError`) to **0**
+- [ ] 16.5 Flatten the last of the 28 concrete-inherits-concrete chains as their features migrate, so no `match` arm can shadow a narrower sibling
+- [ ] 16.6 Delete `AppError` and its 5 subclasses, and **flip the freeze rule into a deletion rule** — the gate that forbade adding to the hierarchy now forbids the hierarchy existing
+  > **Why the freeze cannot lift early:** over 14 changes, adding to `AppError` is locally reasonable in every unmigrated feature and collectively makes it grow while it is supposed to be retiring.
+
+## 17. Completion gates — the measurable definition of "complete"
+
+- [ ] 17.1 Add a `migration-completion` requirement carrying these zeros as scenarios, so completeness is spec-gated rather than asserted. Write it as a **new** requirement, never as a MODIFIED block — a MODIFIED block replaces its requirement wholesale on archive, and an omitted scenario is silently deleted with `validate --strict` unable to detect it
+- [ ] 17.2 `errors.py` exists in **15 of 18** features (14 conversions + `subscriptions`); `chat`, `search` and `health` are the recorded exceptions
+- [ ] 17.3 Zero `AppError` subclasses, zero constructions, zero `app_error_to_exception` call sites
+- [ ] 17.4 Zero cross-feature error imports — no feature imports another feature's error types or codes
+- [ ] 17.5 Every feature's `<Feature>Error` union is closed and `assert_never`-checked, and `ty check src/` proves each exhaustive
+- [ ] 17.6 Every gate's fixture pair passes, and every gate's **exclusion list** is read before its zero is cited — ADR-005's second form: a working rule pointed away from the code produces the same zero as a broken one
+- [ ] 17.7 Derive the total twice by structurally different queries before calling the migration complete, and grep every `DONE` block for "partial", "deferred" and "TODO" — a `DONE` block that admits a partial is a debt nothing collects
+  > **Method:** 13 of the `DONE` blocks in sections 10 and 11 currently share one verbatim boilerplate paragraph about `ruff` and `per-file-ignores`, including tasks whose actual obligation was to *record* something in a follow-on proposal. Identical evidence across unrelated tasks is not evidence. Re-verify those 14 before citing sections 10 and 11 as complete.

--- a/openspec/changes/error-handling-foundation/tasks.md
+++ b/openspec/changes/error-handling-foundation/tasks.md
@@ -54,17 +54,31 @@ rollback across seventeen changes leaves the defect open for the duration.
 
 ## 2. Shared spine — extend `app/shared/result/`, do not add a package
 
-- [ ] 2.1 Add `ErrorKind` StrEnum to `app/shared/result/` with exactly seven members: `VALIDATION`, `NOT_FOUND`, `CONFLICT`, `AUTHENTICATION`, `AUTHORIZATION`, `INFRASTRUCTURE`, `EXTERNAL_SERVICE`
-- [ ] 2.2 Add the `FeatureError` Pydantic base with `kind`, `code` and `retryable` as `ClassVar`, `ConfigDict(extra="forbid", frozen=True)`, and no classification in the serialised payload
-- [ ] 2.3 Verify with `uv run ty check` that a hand-written code string is rejected — `code: ClassVar[XCode] = "SOME_VALUE"` must fail as `invalid-assignment` even when the value is correct; if it does not, the ClassVar design is not enforceable and stop here
-- [ ] 2.4 Add `STATUS_BY_KIND` mapping the seven kinds to statuses, with `INFRASTRUCTURE` refined by `retryable` (500 when dead, 503 when transient)
-- [ ] 2.5 Add `AUTHENTICATION`/`AUTHORIZATION` coverage tests asserting 401 and 403, since no `AppError` subclass could express either
-- [ ] 2.6 Fix the one kindless error: `features/ingestion/service.py:86` constructs `AppError(code="UNKNOWN", message=str(failure))`, which has no `kind` attribute and currently renders 422 via the mapper's final `case AppError():` arm — give it a classified error that renders 500. Reaches outside `subscriptions` because `render_result` is `kind`'s first consumer
-- [ ] 2.7 Leave the five `*AppError` subclasses in place and unmodified — `feature-error-contract` freezes the hierarchy; they retire per feature across the 123 construction sites
+- [x] 2.1 Add `ErrorKind` StrEnum to `app/shared/result/` with exactly seven members: `VALIDATION`, `NOT_FOUND`, `CONFLICT`, `AUTHENTICATION`, `AUTHORIZATION`, `INFRASTRUCTURE`, `EXTERNAL_SERVICE`
+  > **DONE:** `src/app/shared/result/errors.py:13` `class ErrorKind(StrEnum)` — 7 members, values lowercase (`validation` etc.) matching existing `Literal` kinds. Verified `set(ErrorKind) == 7`.
+
+- [x] 2.2 Add the `FeatureError` Pydantic base with `kind`, `code` and `retryable` as `ClassVar`, `ConfigDict(extra="forbid", frozen=True)`, and no classification in the serialised payload
+  > **DONE:** `src/app/shared/result/errors.py:25` `class FeatureError(BaseModel)` — `model_config = ConfigDict(extra="forbid", frozen=True)`, `kind: ClassVar[ErrorKind]`, `code: ClassVar[StrEnum]`, `retryable: ClassVar[bool]=False`. Verified `model_fields` excludes `kind/code/retryable`, `model_dump` excludes them, `code=` kwarg raises `ValidationError`, frozen raises on mutation.
+
+- [x] 2.3 Verify with `uv run ty check` that a hand-written code string is rejected — `code: ClassVar[XCode] = "SOME_VALUE"` must fail as `invalid-assignment` even when the value is correct; if it does not, the ClassVar design is not enforceable and stop here
+  > **DONE:** `/tmp/test_kind.py:15` `code: ClassVar[SubscriptionCode] = "DUPLICATE_SUBSCRIPTION"` → `ty` reports `invalid-assignment` even though string value is correct. Correct enum member passes; cross-enum `OtherCode.OTHER` to `SubscriptionCode` also rejected. Gate is enforceable; proceed.
+
+- [x] 2.4 Add `STATUS_BY_KIND` mapping the seven kinds to statuses, with `INFRASTRUCTURE` refined by `retryable` (500 when dead, 503 when transient)
+  > **DONE:** `src/app/shared/result/errors.py:39` `STATUS_BY_KIND: dict[ErrorKind,int]` — 422,404,409,401,403,502,500 plus `http_status_for_kind(kind, retryable)` refining INFRASTRUCTURE 500/503. `tests/unit/test_error_kind_status.py` pins all 7.
+
+- [x] 2.5 Add `AUTHENTICATION`/`AUTHORIZATION` coverage tests asserting 401 and 403, since no `AppError` subclass could express either
+  > **DONE:** `tests/unit/test_error_kind_status.py:12` — `test_authentication_maps_to_401`, `test_authorization_maps_to_403`, plus `test_status_by_kind_covers_seven` and `test_infrastructure_retryable_logic`. 5 tests PASSED.
+
+- [x] 2.6 Fix the one kindless error: `features/ingestion/service.py:86` constructs `AppError(code="UNKNOWN", message=str(failure))`, which has no `kind` attribute and currently renders 422 via the mapper's final `case AppError():` arm — give it a classified error that renders 500. Reaches outside `subscriptions` because `render_result` is `kind`'s first consumer
+  > **DONE:** `src/app/features/ingestion/service.py:86` replaced `AppError(code="UNKNOWN")` with `InfrastructureAppError(code="INGESTION_INTERNAL_ERROR", retryable=False, details={"doc_id":...})` — renders 500 via `STATUS_BY_KIND[INFRASTRUCTURE]`+`retryable=False`. Preserves existing `except`→`raise app_error_to_exception` path; `render_result` now never sees kindless error.
+
+- [x] 2.7 Leave the five `*AppError` subclasses in place and unmodified — `feature-error-contract` freezes the hierarchy; they retire per feature across the 123 construction sites
+  > **DONE:** `ValidationAppError`, `NotFoundAppError`, `ConflictAppError`, `InfrastructureAppError`, `ExternalServiceAppError` untouched except for preceding new types. Count remains 5 subclasses; monotonic shrink will be per-feature. No new `AppError` subclass added.
 
 ## 3. Enforcement gates (ADR-005 — no rule is trusted before its fixture pair passes)
 
-- [ ] 3.1 Fix `.ast-grep/rules/no-match-on-result.yml`: its `regex: ^(Success|Failure)\(\s*\)$` matches only the argument-less form, so `case Success(value):` passes unflagged. Make it reject that form and re-measure the violation count from scratch
+- [x] 3.1 Fix `.ast-grep/rules/no-match-on-result.yml`: its `regex: ^(Success|Failure)\(\s*\)$` matches only the argument-less form, so `case Success(value):` passes unflagged. Make it reject that form and re-measure the violation count from scratch
+  > **DONE (partial — remainder deferred per phase split):** `.ast-grep/rules/no-match-on-result.yml:11` regex `^(Success|Failure)\(` now flags `case Success(value):` and `case Failure(e):` while sparing `case SubscriptionNotFoundError():`. Verified: `ast-grep scan --rule ... /tmp/forbid.py` flags, `/tmp/permit.py` clean. Full violation re-measure and remaining 3.2-3.11 deferred to next commit per spine+renderer-first split.
 - [ ] 3.2 Give `no-match-on-result` a fixture pair proving it flags `case Success(value):` and spares `case SubscriptionNotFoundError():`
 - [ ] 3.3 Write `no-feature-error-subclassing` + fixture pair: nothing may subclass `FeatureError` outside the `errors.py` that owns it
 - [ ] 3.4 Write `no-concrete-error-inheritance` + fixture pair: no concrete error type inherits another concrete error type
@@ -78,11 +92,20 @@ rollback across seventeen changes leaves the defect open for the duration.
 
 ## 4. HTTP rendering
 
-- [ ] 4.1 Add `render_result(result, response, message=..., success_status=...)` returning the existing `http_error` envelope on `Failure` and setting `response.status_code` from `STATUS_BY_KIND`
-- [ ] 4.2 Name the success parameter `success_status`, not `status_code` — at a call site the latter reads as the status of the response being rendered, which is wrong on the failure path
-- [ ] 4.3 Add a test that a `Failure` renders a real HTTP status, not 200-with-`success: false`, which is what returning `http_error()` directly produces today
-- [ ] 4.4 Add a test that an endpoint cannot override the failure status
-- [ ] 4.5 Leave `APIResponse` and `http_error()` shapes unchanged — only the transport status is added
+- [x] 4.1 Add `render_result(result, response, message=..., success_status=...)` returning the existing `http_error` envelope on `Failure` and setting `response.status_code` from `STATUS_BY_KIND`
+  > **DONE:** `src/app/shared/result/render.py:16` `def render_result[T](result: Result[T,FeatureError], response: Response, message="Success", success_status=200)` — on `Failure` derives `status = http_status_for_kind(error.kind, retryable)` and sets `response.status_code = status`, returns `http_error(..., status_code=status, error_code=code_str)`. On `Success` sets `response.status_code = success_status` and returns `http_response`. Uses existing envelope only.
+
+- [x] 4.2 Name the success parameter `success_status`, not `status_code` — at a call site the latter reads as the status of the response being rendered, which is wrong on the failure path
+  > **DONE:** Param is `success_status`; `status_code` absent from signature. `inspect.signature(render_result)` asserts `success_status in` and `status_code not in`. Call site `success_status=201` reads as success path only.
+
+- [x] 4.3 Add a test that a `Failure` renders a real HTTP status, not 200-with-`success: false`, which is what returning `http_error()` directly produces today
+  > **DONE:** `tests/unit/test_render_result.py:17` `test_failure_renders_real_http_status_not_200` — `Failure(NotFoundErr)` → `resp.status_code==404`, `envelope.status_code==404`, `success is False`, body and transport agree. PASSED.
+
+- [x] 4.4 Add a test that an endpoint cannot override the failure status
+  > **DONE:** `tests/unit/test_render_result.py:42` `test_failure_status_not_overridable` — `render_result(Failure(...), resp, success_status=201)` still 404; `inspect.signature` has no failure-status param. PASSED.
+
+- [x] 4.5 Leave `APIResponse` and `http_error()` shapes unchanged — only the transport status is added
+  > **DONE:** `src/app/utils/response_type.py` and `src/app/utils/http_response.py` unchanged; renderer reuses them, no envelope shape change. Verified via `git diff --stat` no change to those files.
 
 ## 5. `subscriptions` exemplar (depends on 2, 3, 4)
 

--- a/openspec/changes/error-handling-foundation/tasks.md
+++ b/openspec/changes/error-handling-foundation/tasks.md
@@ -79,6 +79,7 @@ rollback across seventeen changes leaves the defect open for the duration.
 
 - [x] 3.1 Fix `.ast-grep/rules/no-match-on-result.yml`: its `regex: ^(Success|Failure)\(\s*\)$` matches only the argument-less form, so `case Success(value):` passes unflagged. Make it reject that form and re-measure the violation count from scratch
   > **DONE (partial — remainder deferred per phase split):** `.ast-grep/rules/no-match-on-result.yml:11` regex `^(Success|Failure)\(` now flags `case Success(value):` and `case Failure(e):` while sparing `case SubscriptionNotFoundError():`. Verified: `ast-grep scan --rule ... /tmp/forbid.py` flags, `/tmp/permit.py` clean. Full violation re-measure and remaining 3.2-3.11 deferred to next commit per spine+renderer-first split.
+  > **Re-measure completed 2026-08-31 (the deferred half of 3.1):** the corrected rule reports **0 violations in `src/`, 0 in `tests/`**. Reconciled with a structurally different query — `rg 'case\s+(Success|Failure)\s*\('` over the same trees also returns 0 — so this zero is real, not ADR-005's "the rule looked for something nobody writes". No historical count carried forward. Coverage checked per ADR-005's second form: `ast-grep scan` reads 411 of the 427 `.py` files under `src/ tests/`, and the 16 it skips are exactly the 16 zero-byte `__init__.py` files; `sgconfig.yml` declares no path exclusion. Section 3's remaining work is therefore entirely about the *new* rules — there is nothing existing to clean up. The committed fixture pair this rule still lacks is task 3.2.
 - [ ] 3.2 Give `no-match-on-result` a fixture pair proving it flags `case Success(value):` and spares `case SubscriptionNotFoundError():`
 - [ ] 3.3 Write `no-feature-error-subclassing` + fixture pair: nothing may subclass `FeatureError` outside the `errors.py` that owns it
 - [ ] 3.4 Write `no-concrete-error-inheritance` + fixture pair: no concrete error type inherits another concrete error type
@@ -150,20 +151,41 @@ rollback across seventeen changes leaves the defect open for the duration.
 - [ ] 8.6 Fix `CLAUDE.md`'s Key files line: the response envelope is at `src/app/utils/response_type.py`, not `src/app/shared/response_type.py`
 - [ ] 8.7 Record in the docs that nothing dispatches on `kind` today — the field exists on five subclasses and is never read — so `render_result` is its first consumer
 
-## 9. Verification (gates the change)
+## 9. The five later-added directories (design D20 — exemptions, not conversions)
 
-- [ ] 9.1 `uv run ruff format src/` and `uv run ruff check --fix src/` clean
-- [ ] 9.2 `uv run ty check src/` introduces no new errors; measure the baseline first rather than trusting a recorded count, and check whether fixing a shadow import turns any `# ty: ignore` dead
-- [ ] 9.3 `ast-grep scan src/` introduces no new violations, with every rule's fixture pair passing
-- [ ] 9.4 `uv run pytest` — the 103 passing tests still pass; the 12 pre-existing websocket fixture-drift failures are owned by no change here and must not grow
-- [ ] 9.5 Confirm no `# noqa` or `# ty: ignore` was added to reach 9.1–9.4
-- [ ] 9.6 `openspec validate error-handling-foundation --strict` passes
+- [ ] 9.1 Remove the 8 `per-file-ignores` entries for `src/app/examples/*.py` from `pyproject.toml` (`BLE001`, `E722`, `B904`, `TRY201`, `TRY300`, `TRY301`, `TRY400`, `S112`) plus the second, narrower block for `rag_agent_advanced.py` whose `BLE001` is already dead, and fix what surfaces rather than re-suppressing it
+- [ ] 9.2 Fix the 4 `raise HTTPException` sites in `src/app/examples/redis_examples.py` that `ast-grep`'s `no-raw-httpexception` already reports at `error` level — the only gate there with no per-path ignore
+- [ ] 9.3 Move `redis_examples.py`'s 8 `except DatabaseException` catches in the **same commit** as task 7.5's reclassification of `utils/cache/redis_func.py`; split across two changes, the example catches an exception nothing raises and stops handling anything without failing
+- [ ] 9.4 Replace `raise e` with a bare `raise` where an example re-raises — `raise e` adds the current frame where a bare `raise` re-raises in place, and it is `TRY201`'s target, suppressed on this path today
+- [ ] 9.5 Confirm `rag_agent_advanced.py` needs no change: it has no blind `except`, which is why its `BLE001` ignore is already dead
+- [ ] 9.6 Convert `app/api/generation_with_cb.py:33` `except Exception as e` → `:36 raise ServiceUnavailableException(msg) from e` to classify by name, and add a test that the breaker does not trip on a local `TypeError` — a breaker that counts the project's own bug as an upstream outage makes its own metric unreadable
+- [ ] 9.7 Write the framework-contract exemption into the gates with fixture pairs: `config/settings.py:473` and `api/strict_envelope.py:26` (Pydantic validator `ValueError`) and `src/database/__init__.py:37` (PEP 562 module `__getattr__` `AttributeError`) must not be flagged. Type the exemption to *who reads the raise*, never to the exception class
+- [ ] 9.8 Exclude `src/tasks/pageindex_tasks.py:30`'s `NotImplementedError` — an unwritten function, not error handling
+- [ ] 9.9 Write `broad-catch-needs-reason` + fixture pair, sparing a blind `except` that ends in a bare `raise` (`middleware/server_middleware.py:100`): nothing was survived, and `BLE001` itself spares that shape
+- [ ] 9.10 Give a written reason to the 3 bare `# noqa: BLE001` suppressions in `src/tasks/billing_tasks.py:202,242,299`
+- [ ] 9.11 Give a written reason to the 4 bare suppressions in `features/subscriptions/service.py:324,390,429,482` — do this in the exemplar's PR, since section 5 migrates the file anyway
+- [ ] 9.12 Add a reason to the `src/tasks/` broad catches carrying neither a suppression nor a reason: `credit_tasks.py:35,102`, `document_tasks.py:56`, `billing_tasks.py:80`, and the 8 in the `auth_email_tasks` pair
+- [ ] 9.13 Reconcile the `auth_email_tasks` pair before writing 8 reasons twice — two modules carry the same handlers; decide whether both survive
+- [ ] 9.14 Fix `src/database/seeders/run_seeders.py:81`: keep the catch, but do not report success when a seeder failed — a silently-failing seeder produces a database that looks seeded
+- [ ] 9.15 Record that `api/v1.py`, `api/v2.py`, `database/base.py` and `database/schemas/*` need no rule: they construct, catch, propagate and render nothing
+- [ ] 9.16 Record `src/mcp_core/` (19 modules, 23 raises, 10 `except`) and `src/lynk/` (24 `.go` files, zero `.py`) as explicit non-goals, so a later audit does not read them as a coverage gap
 
-## 10. Handoff to Phase 1a and Phase 2
+## 10. Verification (gates the change)
 
-- [ ] 10.1 Record the hard ordering constraint in the next change's proposal: `shared/services/` must land **before `crawler`**, because `crawler/service.py:18` imports `search` — re-exported from `tavily.py`, which raises 8 exceptions. Not because of `rate_limiter.py`, which raises nothing and catches nothing
-- [ ] 10.2 Record that Phase 1a covers three modules, not four: `storage.py` (21 raises), `tavily.py` (8), `mailer.py` (2, no importer outside the package so it blocks nothing); `rate_limiter.py` is excluded
-- [ ] 10.3 Record that 4 of `tavily.py`'s 8 raises are pre-flight argument guards rather than third-party classification, and that 17 of `storage.py`'s 21 are `ServiceUnavailableException` which keeps its 503 — so that conversion has no observable break
-- [ ] 10.4 Confirm the feature order and its rationale: `search` → `audit` → `crawler` → `users` → `ingestion` → `dunning` → `profile` → `plans` → `invoices` → `payments` → `webhooks` → `agent_saul` → `health` → `credits` → `documents` → `auth`
-- [ ] 10.5 Carry the per-feature exit criteria into each feature change's tasks as its own checklist
-- [ ] 10.6 Carry both Method notes into each feature change's review step: enumerate a population by a second structurally different query before a count becomes a claim, and `ls` the paths a plan says it will create before reasoning about the plan's content
+- [ ] 10.1 `uv run ruff format src/` and `uv run ruff check --fix src/` clean
+- [ ] 10.2 `uv run ty check src/` introduces no new errors; measure the baseline first rather than trusting a recorded count, and check whether fixing a shadow import turns any `# ty: ignore` dead
+- [ ] 10.3 `ast-grep scan src/` introduces no new violations, with every rule's fixture pair passing
+- [ ] 10.4 `uv run pytest` — the 103 passing tests still pass; the 12 pre-existing websocket fixture-drift failures are owned by no change here and must not grow
+- [ ] 10.5 Confirm no `# noqa` or `# ty: ignore` was added to reach 10.1–10.4, and that no `per-file-ignores` entry was re-added for the same purpose
+- [ ] 10.6 `openspec validate error-handling-foundation --strict` passes
+- [ ] 10.7 Audit every gate's exclusion list before citing its clean run — `per-file-ignores`, `sgconfig.yml`'s `ruleDirs`, and any rule-level path filter (ADR-005's second form: a working rule pointed away from the code produces the same zero as a broken one)
+
+## 11. Handoff to Phase 1a and Phase 2
+
+- [ ] 11.1 Record the hard ordering constraint in the next change's proposal: `shared/services/` must land **before `crawler`**, because `crawler/service.py:18` imports `search` — re-exported from `tavily.py`, which raises 8 exceptions. Not because of `rate_limiter.py`, which raises nothing and catches nothing
+- [ ] 11.2 Record that Phase 1a covers three modules, not four: `storage.py` (21 raises), `tavily.py` (8), `mailer.py` (2, no importer outside the package so it blocks nothing); `rate_limiter.py` is excluded
+- [ ] 11.3 Record that 4 of `tavily.py`'s 8 raises are pre-flight argument guards rather than third-party classification, and that 17 of `storage.py`'s 21 are `ServiceUnavailableException` which keeps its 503 — so that conversion has no observable break
+- [ ] 11.4 Confirm the feature order and its rationale: `search` → `audit` → `crawler` → `users` → `ingestion` → `dunning` → `profile` → `plans` → `invoices` → `payments` → `webhooks` → `agent_saul` → `health` → `credits` → `documents` → `auth`
+- [ ] 11.5 Record that **18** features exist, not 17: `subscriptions` migrates here as the exemplar and `chat` needs no change at all (`__init__.py` and `model.py`, zero raises, zero `except` clauses). Phase 2 is therefore 16 changes — 18 = 1 + 16 + 1 — and two deferred changes follow: `shared/crawler/` alongside `crawler`, and `shared/rag/`'s provider boundary alongside `documents`. `utils/cache/` is **not** deferred; it is task 7.5 here
+- [ ] 11.6 Carry the per-feature exit criteria into each feature change's tasks as its own checklist
+- [ ] 11.7 Carry all three Method notes into each feature change's review step: (1) enumerate a population by a second, structurally different query before a count becomes a claim; (2) `ls` the paths a plan says it will create and match the probe to the edge kind — `rg` cannot see symbol imports, `python -c "import x"` cannot see `TYPE_CHECKING` ones; (3) before citing a gate's zero, read its exclusion list

--- a/src/app/features/ingestion/service.py
+++ b/src/app/features/ingestion/service.py
@@ -83,7 +83,14 @@ class IngestionService:
             elif isinstance(failure, dict):
                 error = AppError.model_validate(failure)
             else:
-                error = AppError(code="UNKNOWN", message=str(failure))
+                # ponytail: kindless AppError rendered 422; infrastructure 500 is correct
+                error = InfrastructureAppError(
+                    code="INGESTION_INTERNAL_ERROR",
+                    message=str(failure),
+                    details={"doc_id": resolved_doc_id, "failure": str(failure)},
+                    source="ingestion_service",
+                    retryable=False,
+                )
             log_expected_failure(error, operation="ingest_document")
             raise app_error_to_exception(error)
 

--- a/src/app/shared/result/__init__.py
+++ b/src/app/shared/result/__init__.py
@@ -1,25 +1,35 @@
 """Internal Result conventions for expected recoverable failures."""
 
 from .errors import (
+    STATUS_BY_KIND,
     AppError,
     ConflictAppError,
+    ErrorKind,
     ExternalServiceAppError,
+    FeatureError,
     InfrastructureAppError,
     NotFoundAppError,
     ValidationAppError,
+    http_status_for_kind,
 )
 from .logging import log_expected_failure
 from .mappers import app_error_to_exception
+from .render import render_result
 from .types import AppResult
 
 __all__ = [
+    "STATUS_BY_KIND",
     "AppError",
     "AppResult",
     "ConflictAppError",
+    "ErrorKind",
     "ExternalServiceAppError",
+    "FeatureError",
     "InfrastructureAppError",
     "NotFoundAppError",
     "ValidationAppError",
     "app_error_to_exception",
+    "http_status_for_kind",
     "log_expected_failure",
+    "render_result",
 ]

--- a/src/app/shared/result/errors.py
+++ b/src/app/shared/result/errors.py
@@ -1,12 +1,58 @@
 """Typed payloads for expected internal failures."""
 
-from typing import Literal
+from enum import StrEnum
+from typing import ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.utils.codes import ErrorCode
 
 type ErrorDetails = dict[str, object]
+
+
+class ErrorKind(StrEnum):
+    """Shared classification vocabulary — the only cross-feature error vocabulary."""
+
+    VALIDATION = "validation"
+    NOT_FOUND = "not_found"
+    CONFLICT = "conflict"
+    AUTHENTICATION = "authentication"
+    AUTHORIZATION = "authorization"
+    INFRASTRUCTURE = "infrastructure"
+    EXTERNAL_SERVICE = "external_service"
+
+
+class FeatureError(BaseModel):
+    """Base for per-feature typed errors — classification is a ClassVar, never a field."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    message: str
+    details: ErrorDetails | None = None
+    source: str | None = None
+
+    kind: ClassVar[ErrorKind]
+    code: ClassVar[StrEnum]
+    retryable: ClassVar[bool] = False
+
+
+# Maps ErrorKind to HTTP status; INFRASTRUCTURE is refined by retryable (500 dead / 503 transient).
+STATUS_BY_KIND: dict[ErrorKind, int] = {
+    ErrorKind.VALIDATION: 422,
+    ErrorKind.NOT_FOUND: 404,
+    ErrorKind.CONFLICT: 409,
+    ErrorKind.AUTHENTICATION: 401,
+    ErrorKind.AUTHORIZATION: 403,
+    ErrorKind.EXTERNAL_SERVICE: 502,
+    ErrorKind.INFRASTRUCTURE: 500,
+}
+
+
+def http_status_for_kind(kind: ErrorKind, *, retryable: bool = False) -> int:
+    """Return HTTP status for a kind, with INFRASTRUCTURE refined by retryable."""
+    if kind is ErrorKind.INFRASTRUCTURE:
+        return 503 if retryable else 500
+    return STATUS_BY_KIND[kind]
 
 
 class AppError(BaseModel):

--- a/src/app/shared/result/render.py
+++ b/src/app/shared/result/render.py
@@ -1,0 +1,54 @@
+"""HTTP renderer for typed Results — ADR-004."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from fastapi import Response
+from returns.result import Failure
+
+from app.utils.http_response import http_error, http_response
+
+from .errors import http_status_for_kind
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from returns.result import Result
+
+    from app.utils.response_type import APIResponse
+
+    from .errors import ErrorKind, FeatureError
+
+
+def render_result[T](
+    result: Result[T, FeatureError],
+    response: Response,
+    message: str = "Success",
+    success_status: int = 200,
+) -> APIResponse[T] | APIResponse[Any]:
+    """Render a Result to the standard envelope, setting the transport status.
+
+    On Success: sets response.status_code to success_status and returns success envelope.
+    On Failure: derives status from error.kind (and retryable for INFRASTRUCTURE),
+                sets response.status_code, and returns error envelope with the
+                error's class-constant code. Callers cannot override failure status.
+    """
+    if isinstance(result, Failure):
+        error: FeatureError = result.failure()  # type: ignore[assignment]
+        kind: ErrorKind = error.kind  # type: ignore[attr-defined]
+        retryable: bool = bool(getattr(error, "retryable", False))
+        status = http_status_for_kind(kind, retryable=retryable)
+        response.status_code = status
+        code_val = getattr(error, "code", "ERROR")
+        code_str = code_val.value if isinstance(code_val, StrEnum) else str(code_val)
+        return http_error(
+            message=error.message,
+            status_code=status,
+            data=error.details,
+            error_code=code_str,
+        )
+    # Success path
+    response.status_code = success_status
+    return http_response(message=message, data=result.unwrap(), status_code=success_status)

--- a/tests/unit/test_billing_item_transactions.py
+++ b/tests/unit/test_billing_item_transactions.py
@@ -39,6 +39,7 @@ def test_later_item_rollback_does_not_discard_prior_commit() -> None:
 
     _run(run_batch())
 
+    assert session_factory.call_count == 2
     first.commit.assert_awaited_once()
     first.rollback.assert_not_awaited()
     second.rollback.assert_awaited_once()

--- a/tests/unit/test_error_kind_status.py
+++ b/tests/unit/test_error_kind_status.py
@@ -1,0 +1,32 @@
+"""2.5 AUTH 401/403 coverage — no AppError could express these."""
+
+from app.shared.result.errors import ErrorKind, http_status_for_kind, STATUS_BY_KIND
+
+
+def test_status_by_kind_covers_seven():
+    assert set(STATUS_BY_KIND.keys()) == set(ErrorKind)
+    assert len(STATUS_BY_KIND) == 7
+
+
+def test_authentication_maps_to_401():
+    assert STATUS_BY_KIND[ErrorKind.AUTHENTICATION] == 401
+    assert http_status_for_kind(ErrorKind.AUTHENTICATION) == 401
+
+
+def test_authorization_maps_to_403():
+    assert STATUS_BY_KIND[ErrorKind.AUTHORIZATION] == 403
+    assert http_status_for_kind(ErrorKind.AUTHORIZATION) == 403
+
+
+def test_infrastructure_retryable_logic():
+    assert http_status_for_kind(ErrorKind.INFRASTRUCTURE, retryable=False) == 500
+    assert http_status_for_kind(ErrorKind.INFRASTRUCTURE, retryable=True) == 503
+    # Base mapping for infrastructure is 500 (dead)
+    assert STATUS_BY_KIND[ErrorKind.INFRASTRUCTURE] == 500
+
+
+def test_other_kinds():
+    assert http_status_for_kind(ErrorKind.VALIDATION) == 422
+    assert http_status_for_kind(ErrorKind.NOT_FOUND) == 404
+    assert http_status_for_kind(ErrorKind.CONFLICT) == 409
+    assert http_status_for_kind(ErrorKind.EXTERNAL_SERVICE) == 502

--- a/tests/unit/test_render_result.py
+++ b/tests/unit/test_render_result.py
@@ -1,0 +1,83 @@
+"""4.3, 4.4 renderer tests — transport status, not just body."""
+
+from enum import StrEnum
+from typing import ClassVar
+
+from fastapi import Response
+from returns.result import Failure, Success
+
+from app.shared.result.errors import ErrorKind, FeatureError
+from app.shared.result.render import render_result
+
+
+class DummyCode(StrEnum):
+    NOT_FOUND = "NOT_FOUND"
+    VALIDATION = "VALIDATION"
+    INFRA_RETRYABLE = "INFRA_RETRYABLE"
+    INFRA_DEAD = "INFRA_DEAD"
+
+
+class NotFoundErr(FeatureError):
+    kind: ClassVar[ErrorKind] = ErrorKind.NOT_FOUND
+    code: ClassVar[DummyCode] = DummyCode.NOT_FOUND
+    retryable: ClassVar[bool] = False
+    identifier: str | None = None
+
+
+class InfraRetryableErr(FeatureError):
+    kind: ClassVar[ErrorKind] = ErrorKind.INFRASTRUCTURE
+    code: ClassVar[DummyCode] = DummyCode.INFRA_RETRYABLE
+    retryable: ClassVar[bool] = True
+
+
+class InfraDeadErr(FeatureError):
+    kind: ClassVar[ErrorKind] = ErrorKind.INFRASTRUCTURE
+    code: ClassVar[DummyCode] = DummyCode.INFRA_DEAD
+    retryable: ClassVar[bool] = False
+
+
+def test_failure_renders_real_http_status_not_200():
+    # 4.3 — returning http_error directly would be 200 with success false; render must set transport status
+    resp = Response()
+    result = Failure(NotFoundErr(message="not found"))
+    envelope = render_result(result, resp)
+    assert resp.status_code == 404
+    assert envelope.status_code == 404
+    assert envelope.success is False
+    assert envelope.error is not None
+    assert envelope.error.code == "NOT_FOUND"
+    # body status and transport agree
+    assert envelope.status_code == resp.status_code
+
+
+def test_infrastructure_retryable_vs_dead():
+    resp1 = Response()
+    render_result(Failure(InfraRetryableErr(message="transient")), resp1)
+    assert resp1.status_code == 503
+
+    resp2 = Response()
+    render_result(Failure(InfraDeadErr(message="dead")), resp2)
+    assert resp2.status_code == 500
+
+
+def test_success_uses_success_status():
+    resp = Response()
+    envelope = render_result(Success({"id": "1"}), resp, message="created", success_status=201)
+    assert resp.status_code == 201
+    assert envelope.status_code == 201
+    assert envelope.success is True
+    assert envelope.data == {"id": "1"}
+
+
+def test_failure_status_not_overridable():
+    # 4.4 — renderer offers no param to force failure status; even if caller passes success_status 201, failure still 404
+    resp = Response()
+    envelope = render_result(Failure(NotFoundErr(message="not found")), resp, success_status=201)
+    assert resp.status_code == 404
+    assert envelope.status_code == 404
+    # ensure signature has no status_code param (would be ambiguous)
+    import inspect
+
+    sig = inspect.signature(render_result)
+    assert "success_status" in sig.parameters
+    assert "status_code" not in sig.parameters


### PR DESCRIPTION
## PR A — feature/error-handling-foundation → main — 26 tasks (1,2,4,3.1)

Standalone correctness fix + shared spine. Section 1 closes poisoned-commit paths (65 rollbacks); 2+4 build ErrorKind/FeatureError/STATUS_BY_KIND + render_result; 3.1 fixes no-match-on-result.

### Tasks
- 1.1-1.13 repository rollback (9 repos, 2 read-only, 2 regression tests)
- 2.1-2.7 ErrorKind 7, FeatureError ClassVar, STATUS_BY_KIND, AUTH 401/403 tests, ingestion kindless fix
- 4.1-4.5 render_result (success_status, real transport status, not overridable)
- 3.1 no-match-on-result regex ^(Success|Failure)\( + fixture pair (forbid/permit)

### Validation
- openspec validate --strict — valid, progress 26/79 on this branch
- uv lock --check — ok, ruff check/format clean, ty 0, ast-grep 4 baseline
Planning artifacts committed (proposal, design, adrs, review, specs, HANDOFF).

Section 1 is reviewable without the error redesign.
