### PR TITLE
fix(open-deep-search): bound provider fan-out and failures

### DIFF
--- a/src/app/shared/langgraph_layer/open_deep_search/config.py
+++ b/src/app/shared/langgraph_layer/open_deep_search/config.py
@@ -11,6 +11,8 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from app.config import get_settings
 
+from .execution import get_research_execution_gate
+
 if TYPE_CHECKING:
     from typing import Any
 
@@ -28,6 +30,10 @@ class Configuration(BaseModel):
     max_structured_output_retries: int = Field(default=3, ge=1, le=10)
     allow_clarification: bool = True
     max_concurrent_research_units: int = Field(default=5, ge=1, le=20)
+    max_concurrent_research_tools: int = Field(default=5, ge=1, le=20)
+    max_concurrent_search_requests: int = Field(default=10, ge=1, le=20)
+    max_concurrent_summaries: int = Field(default=10, ge=1, le=20)
+    max_search_queries: int = Field(default=5, ge=1, le=20)
     max_researcher_iterations: int = Field(default=6, ge=1, le=10)
     max_react_tool_calls: int = Field(default=10, ge=1, le=30)
 
@@ -72,6 +78,11 @@ def build_open_deep_search_config(
             "httpx_client": request.app.state.httpx_client,
             "tavily_http_client": getattr(request.app.state, "tavily_http_client", None),
             "crawl4ai_crawler": getattr(request.app.state, "crawl4ai_crawler", None),
+            "research_execution_gate": getattr(
+                request.app.state,
+                "research_execution_gate",
+                get_research_execution_gate(),
+            ),
             **(configurable or {}),
         },
         metadata=metadata or {},

--- a/src/app/shared/langgraph_layer/open_deep_search/config.py
+++ b/src/app/shared/langgraph_layer/open_deep_search/config.py
@@ -35,6 +35,7 @@ class Configuration(BaseModel):
     max_concurrent_summaries: int = Field(default=10, ge=1, le=20)
     max_search_queries: int = Field(default=5, ge=1, le=20)
     max_researcher_iterations: int = Field(default=6, ge=1, le=10)
+    max_tool_calls_per_turn: int = Field(default=10, ge=1, le=30)
     max_react_tool_calls: int = Field(default=10, ge=1, le=30)
 
     summarization_model: str = Field(default_factory=lambda: get_settings().GEMINI_FLASH_MODEL)

--- a/src/app/shared/langgraph_layer/open_deep_search/execution.py
+++ b/src/app/shared/langgraph_layer/open_deep_search/execution.py
@@ -1,0 +1,79 @@
+"""Concurrency controls for immediate deep-research provider calls."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Iterable
+
+    from langchain_core.runnables import RunnableConfig
+
+
+class ResearchExecutionGate:
+    """Limit provider work shared by deep-research runs in one process."""
+
+    def __init__(
+        self,
+        *,
+        max_concurrent_search_requests: int = 10,
+        max_concurrent_summaries: int = 10,
+    ) -> None:
+        if max_concurrent_search_requests < 1:
+            msg = "max_concurrent_search_requests must be at least 1"
+            raise ValueError(msg)
+        if max_concurrent_summaries < 1:
+            msg = "max_concurrent_summaries must be at least 1"
+            raise ValueError(msg)
+        self._search_slots = asyncio.Semaphore(max_concurrent_search_requests)
+        self._summary_slots = asyncio.Semaphore(max_concurrent_summaries)
+
+    async def run_search[T](self, operation: Callable[[], Awaitable[T]]) -> T:
+        """Run one search operation while holding a process-local search slot."""
+        async with self._search_slots:
+            return await operation()
+
+    async def run_summary[T](self, operation: Callable[[], Awaitable[T]]) -> T:
+        """Run one summarization operation while holding a process-local slot."""
+        async with self._summary_slots:
+            return await operation()
+
+
+_DEFAULT_RESEARCH_EXECUTION_GATE = ResearchExecutionGate()
+
+
+def get_research_execution_gate(config: RunnableConfig | None = None) -> ResearchExecutionGate:
+    """Return the injected gate or the process-local default gate."""
+    if config:
+        configurable = config.get("configurable", {})
+        gate = configurable.get("research_execution_gate")
+        if isinstance(gate, ResearchExecutionGate):
+            return gate
+    return _DEFAULT_RESEARCH_EXECUTION_GATE
+
+
+async def gather_limited[T](
+    operations: Iterable[Callable[[], Awaitable[T]]],
+    *,
+    limit: int,
+) -> list[T]:
+    """Run awaitable factories with a per-invocation concurrency limit."""
+    if limit < 1:
+        msg = "limit must be at least 1"
+        raise ValueError(msg)
+
+    semaphore = asyncio.Semaphore(limit)
+
+    async def run(operation: Callable[[], Awaitable[T]]) -> T:
+        async with semaphore:
+            return await operation()
+
+    tasks = [asyncio.create_task(run(operation)) for operation in operations]
+    try:
+        return list(await asyncio.gather(*tasks))
+    except BaseException:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise

--- a/src/app/shared/langgraph_layer/open_deep_search/execution.py
+++ b/src/app/shared/langgraph_layer/open_deep_search/execution.py
@@ -1,4 +1,9 @@
-"""Concurrency controls for immediate deep-research provider calls."""
+"""Concurrency controls for immediate deep-research provider calls.
+
+The execution gate is process-local. Deployments with multiple web workers or
+replicas must enforce aggregate provider quotas at a shared rate limiter,
+provider gateway, or the provider itself.
+"""
 
 from __future__ import annotations
 
@@ -20,6 +25,7 @@ class ResearchExecutionGate:
         max_concurrent_search_requests: int = 10,
         max_concurrent_summaries: int = 10,
     ) -> None:
+        """Create provider slots for one application process."""
         if max_concurrent_search_requests < 1:
             msg = "max_concurrent_search_requests must be at least 1"
             raise ValueError(msg)
@@ -44,7 +50,11 @@ _DEFAULT_RESEARCH_EXECUTION_GATE = ResearchExecutionGate()
 
 
 def get_research_execution_gate(config: RunnableConfig | None = None) -> ResearchExecutionGate:
-    """Return the injected gate or the process-local default gate."""
+    """Return the injected gate or process-local default.
+
+    This limits work within one process only; deployment-wide limits belong in
+    shared infrastructure or provider-side rate limiting.
+    """
     if config:
         configurable = config.get("configurable", {})
         gate = configurable.get("research_execution_gate")

--- a/src/app/shared/langgraph_layer/open_deep_search/graph.py
+++ b/src/app/shared/langgraph_layer/open_deep_search/graph.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import (  # noqa: TC003 — Literal resolved at runtime by LangGraph get_type_hints
     TYPE_CHECKING,
     Literal,
@@ -165,7 +164,7 @@ async def supervisor_tools(
     state: SupervisorState,
     config: RunnableConfig,
 ) -> Command[Literal["supervisor", "__end__"]]:
-    """Execute supervisor tool calls for reflection and research delegation."""
+    """Execute supervisor tool calls with bounded, cancellation-safe delegation."""
     configurable: Configuration = Configuration.from_runnable_config(config)
     supervisor_messages = state.get("supervisor_messages", [])
     research_iterations: int = state.get("research_iterations", 0)
@@ -205,9 +204,9 @@ async def supervisor_tools(
         allowed_calls = conduct_research_calls[: configurable.max_concurrent_research_units]
         overflow_calls = conduct_research_calls[configurable.max_concurrent_research_units :]
         try:
-            tool_results = await asyncio.gather(
-                *(
-                    researcher_subgraph.ainvoke(
+            tool_results = await gather_limited(
+                (
+                    lambda tool_call=tool_call: researcher_subgraph.ainvoke(
                         cast(
                             "Any",
                             {
@@ -220,7 +219,8 @@ async def supervisor_tools(
                         config,
                     )
                     for tool_call in allowed_calls
-                )
+                ),
+                limit=configurable.max_concurrent_research_units,
             )
         except (RuntimeError, ValueError, AttributeError) as exc:
             logger.bind(operation="supervisor_tool", error=str(exc)).warning(
@@ -309,7 +309,7 @@ async def researcher(
 def route_researcher(
     state: ResearcherState,
 ) -> Literal["researcher_tools", "compress_research"]:
-    """Router: crawl calls go to crawl_executor, other tool calls go to researcher_tools."""
+    """Route all tool calls to researcher_tools; otherwise, compress research."""
     researcher_messages = state.get("researcher_messages", [])
     if not researcher_messages:
         return "compress_research"
@@ -333,7 +333,7 @@ async def researcher_tools(
     state: ResearcherState,
     config: RunnableConfig,
 ) -> Command[Literal["researcher", "compress_research"]]:
-    """Execute researcher tool calls."""
+    """Execute recognized calls with per-turn and concurrent-call limits."""
     configurable = Configuration.from_runnable_config(config)
     researcher_messages = state.get("researcher_messages", [])
     most_recent_message = cast("Any", researcher_messages[-1])
@@ -344,24 +344,34 @@ async def researcher_tools(
     tools_by_name = {tool_to_call.name: tool_to_call for tool_to_call in tools}
     tool_calls = list(most_recent_message.tool_calls)
     known_tool_calls = [tool_call for tool_call in tool_calls if tool_call["name"] in tools_by_name]
+    allowed_tool_calls = known_tool_calls[: configurable.max_tool_calls_per_turn]
+    overflow_tool_call_ids = {
+        tool_call["id"] for tool_call in known_tool_calls[configurable.max_tool_calls_per_turn :]
+    }
     observations = await gather_limited(
         (
             lambda tool_call=tool_call: execute_tool_safely(
                 tools_by_name[tool_call["name"]], tool_call["args"], config
             )
-            for tool_call in known_tool_calls
+            for tool_call in allowed_tool_calls
         ),
         limit=configurable.max_concurrent_research_tools,
     )
     observations_by_id = {
         tool_call["id"]: observation
-        for observation, tool_call in zip(observations, known_tool_calls, strict=True)
+        for observation, tool_call in zip(observations, allowed_tool_calls, strict=True)
     }
+    overflow_message = (
+        "Error: maximum tool calls per turn exceeded. "
+        f"Retry with {configurable.max_tool_calls_per_turn} or fewer tool calls."
+    )
     tool_outputs = [
         ToolMessage(
             content=(
                 f"Tool unavailable: {tool_call['name']}"
                 if tool_call["name"] not in tools_by_name
+                else overflow_message
+                if tool_call["id"] in overflow_tool_call_ids
                 else observations_by_id[tool_call["id"]]
             ),
             name=tool_call["name"],
@@ -372,7 +382,7 @@ async def researcher_tools(
 
     exceeded_iterations = state.get("tool_call_iterations", 0) >= configurable.max_react_tool_calls
     research_complete = any(
-        tool_call["name"] == "ResearchComplete" for tool_call in known_tool_calls
+        tool_call["name"] == "ResearchComplete" for tool_call in allowed_tool_calls
     )
     if exceeded_iterations or research_complete:
         return Command(goto="compress_research", update={"researcher_messages": tool_outputs})  # ty: ignore[invalid-return-type]

--- a/src/app/shared/langgraph_layer/open_deep_search/graph.py
+++ b/src/app/shared/langgraph_layer/open_deep_search/graph.py
@@ -22,9 +22,10 @@ from langgraph.graph import END, START, StateGraph
 from langgraph.types import Command
 
 from app.shared.langchain_layer.models import _build_chat_model
-from app.utils import logger
+from app.utils import ExternalServiceException, logger
 
 from .config import Configuration
+from .execution import gather_limited
 from .prompts import (
     _CLARIFY_WITH_USER_PROMPT,
     _COMPRESS_RESEARCH_SYSTEM_PROMPT,
@@ -281,7 +282,7 @@ supervisor_subgraph = supervisor_builder.compile()
 async def researcher(
     state: ResearcherState,
     config: RunnableConfig,
-) -> Command[Literal["researcher_tools", "crawl_executor", "compress_research"]]:
+) -> Command[Literal["researcher_tools", "compress_research"]]:
     """Conduct focused research on one supervisor-assigned topic."""
     configurable = Configuration.from_runnable_config(config)
     tools = await get_all_tools(config)
@@ -307,7 +308,7 @@ async def researcher(
 
 def route_researcher(
     state: ResearcherState,
-) -> Literal["researcher_tools", "crawl_executor", "compress_research"]:
+) -> Literal["researcher_tools", "compress_research"]:
     """Router: crawl calls go to crawl_executor, other tool calls go to researcher_tools."""
     researcher_messages = state.get("researcher_messages", [])
     if not researcher_messages:
@@ -316,22 +317,14 @@ def route_researcher(
     if not most_recent.tool_calls:
         return "compress_research"
 
-    tool_names = {tc["name"] for tc in most_recent.tool_calls}
-    has_crawl = "crawl_webpage" in tool_names
-    has_other = any(name != "crawl_webpage" for name in tool_names)
-
-    if has_crawl:
-        return "crawl_executor"
-    if has_other:
-        return "researcher_tools"
-    return "compress_research"
+    return "researcher_tools"
 
 
 async def execute_tool_safely(tool_to_call, args: dict[str, object], config: RunnableConfig) -> str:
     """Execute a research tool and convert failures into model-visible observations."""
     try:
         return str(await tool_to_call.ainvoke(args, config))
-    except LangChainException as exc:
+    except (ExternalServiceException, LangChainException, TimeoutError) as exc:
         exc.add_note(f"tool={tool_to_call.name}")
         return f"Error executing tool: {exc!s}"
 
@@ -349,77 +342,41 @@ async def researcher_tools(
 
     tools = await get_all_tools(config)
     tools_by_name = {tool_to_call.name: tool_to_call for tool_to_call in tools}
-    tool_calls = [
-        tool_call
-        for tool_call in most_recent_message.tool_calls
-        if tool_call["name"] in tools_by_name and tool_call["name"] != "crawl_webpage"
-    ]
-    observations = await asyncio.gather(
-        *(
-            execute_tool_safely(tools_by_name[tool_call["name"]], tool_call["args"], config)
-            for tool_call in tool_calls
-        )
+    tool_calls = list(most_recent_message.tool_calls)
+    known_tool_calls = [tool_call for tool_call in tool_calls if tool_call["name"] in tools_by_name]
+    observations = await gather_limited(
+        (
+            lambda tool_call=tool_call: execute_tool_safely(
+                tools_by_name[tool_call["name"]], tool_call["args"], config
+            )
+            for tool_call in known_tool_calls
+        ),
+        limit=configurable.max_concurrent_research_tools,
     )
+    observations_by_id = {
+        tool_call["id"]: observation
+        for observation, tool_call in zip(observations, known_tool_calls, strict=True)
+    }
     tool_outputs = [
         ToolMessage(
-            content=observation,
+            content=(
+                f"Tool unavailable: {tool_call['name']}"
+                if tool_call["name"] not in tools_by_name
+                else observations_by_id[tool_call["id"]]
+            ),
             name=tool_call["name"],
             tool_call_id=tool_call["id"],
         )
-        for observation, tool_call in zip(observations, tool_calls, strict=True)
+        for tool_call in tool_calls
     ]
 
     exceeded_iterations = state.get("tool_call_iterations", 0) >= configurable.max_react_tool_calls
-    research_complete = any(tool_call["name"] == "ResearchComplete" for tool_call in tool_calls)
+    research_complete = any(
+        tool_call["name"] == "ResearchComplete" for tool_call in known_tool_calls
+    )
     if exceeded_iterations or research_complete:
         return Command(goto="compress_research", update={"researcher_messages": tool_outputs})  # ty: ignore[invalid-return-type]
     return Command(goto="researcher", update={"researcher_messages": tool_outputs})  # ty: ignore[invalid-return-type]
-
-
-async def crawl_executor(
-    state: ResearcherState,
-    config: RunnableConfig,
-) -> Command[Literal["researcher_tools", "researcher", "compress_research"]]:
-    """Execute crawl_webpage tool calls from the researcher."""
-    configurable = Configuration.from_runnable_config(config)
-    researcher_messages = state.get("researcher_messages", [])
-    if not researcher_messages:
-        return Command(goto="compress_research")  # ty: ignore[invalid-return-type]
-    most_recent_message = cast("Any", researcher_messages[-1])
-
-    if not most_recent_message.tool_calls:
-        return Command(goto="compress_research")  # ty: ignore[invalid-return-type]
-
-    crawl_calls = [tc for tc in most_recent_message.tool_calls if tc["name"] == "crawl_webpage"]
-    if not crawl_calls:
-        return Command(goto="compress_research")  # ty: ignore[invalid-return-type]
-
-    tools = await get_all_tools(config)
-    tools_by_name = {t.name: t for t in tools}
-    crawl_tool = tools_by_name.get("crawl_webpage")
-
-    if not crawl_tool:
-        return Command(goto="compress_research")  # ty: ignore[invalid-return-type]
-
-    observations = await asyncio.gather(
-        *(execute_tool_safely(crawl_tool, call["args"], config) for call in crawl_calls)
-    )
-    crawl_outputs = [
-        ToolMessage(content=obs, name=call["name"], tool_call_id=call["id"])
-        for obs, call in zip(observations, crawl_calls, strict=True)
-    ]
-
-    non_crawl_calls = [tc for tc in most_recent_message.tool_calls if tc["name"] != "crawl_webpage"]
-    if non_crawl_calls:
-        return Command(goto="researcher_tools", update={"researcher_messages": crawl_outputs})  # ty: ignore[invalid-return-type]
-
-    exceeded = state.get("tool_call_iterations", 0) >= configurable.max_react_tool_calls
-    research_complete = any(
-        tc["name"] == "ResearchComplete" for tc in most_recent_message.tool_calls
-    )
-    if exceeded or research_complete:
-        return Command(goto="compress_research", update={"researcher_messages": crawl_outputs})  # ty: ignore[invalid-return-type]
-    return Command(goto="researcher", update={"researcher_messages": crawl_outputs})  # ty: ignore[invalid-return-type]
 
 
 async def compress_research(
@@ -471,7 +428,6 @@ researcher_builder = state_graph_factory(
 researcher_builder.add_edge(START, "researcher")
 researcher_builder.add_node("researcher", researcher)
 researcher_builder.add_node("researcher_tools", researcher_tools)
-researcher_builder.add_node("crawl_executor", crawl_executor)
 researcher_builder.add_node("compress_research", compress_research)
 researcher_builder.add_conditional_edges("researcher", route_researcher)
 researcher_builder.add_edge("compress_research", END)

--- a/src/app/shared/langgraph_layer/open_deep_search/tools.py
+++ b/src/app/shared/langgraph_layer/open_deep_search/tools.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     import httpx
     from langchain_core.tools.base import BaseTool
 
+    from .execution import ResearchExecutionGate
+
 
 class DeepResearchInput(BaseModel):
     """Input schema for the Agent Saul deep research tool."""
@@ -42,6 +44,7 @@ class DeepResearchOutput(BaseModel):
 def make_deep_research_tool(
     *,
     http_client: httpx.AsyncClient | None = None,
+    execution_gate: ResearchExecutionGate | None = None,
 ) -> BaseTool:
     """Build a ToolNode-compatible deep research tool."""
 
@@ -60,6 +63,7 @@ def make_deep_research_tool(
                     "max_researcher_iterations": max_researcher_iterations,
                     "httpx_client": http_client,
                     "tavily_http_client": http_client,
+                    "research_execution_gate": execution_gate,
                 }
             },
         )

--- a/src/app/shared/langgraph_layer/open_deep_search/tools.py
+++ b/src/app/shared/langgraph_layer/open_deep_search/tools.py
@@ -54,6 +54,7 @@ def make_deep_research_tool(
         max_concurrent_research_units: int = 3,
         max_researcher_iterations: int = 4,
     ) -> str:
+        """Invoke the deep-research graph for one user question."""
         result = await deep_researcher.ainvoke(
             cast("Any", {"messages": [HumanMessage(content=question)]}),
             config={

--- a/src/app/shared/langgraph_layer/open_deep_search/utils.py
+++ b/src/app/shared/langgraph_layer/open_deep_search/utils.py
@@ -13,6 +13,7 @@ from typing import (  # noqa: TC003 — Annotated, Any, Literal used at runtime 
 )
 
 import httpx
+from langchain_core.exceptions import LangChainException
 from langchain_core.messages import AIMessage, HumanMessage, filter_messages
 from langchain_core.runnables import (
     RunnableConfig,  # noqa: TC002 — RunnableConfig used at runtime by LangChain tool
@@ -25,6 +26,7 @@ from app.shared.services import search
 from app.utils import ExternalServiceException, logger
 
 from .config import Configuration
+from .execution import gather_limited, get_research_execution_gate
 from .prompts import _SUMMARIZE_WEBPAGE_PROMPT
 from .state import ResearchComplete, Summary
 
@@ -48,6 +50,7 @@ async def tavily_search(
     config: RunnableConfig | None = None,
 ) -> str:
     """Fetch and summarize Tavily search results."""
+    configurable: Configuration = Configuration.from_runnable_config(config)
     search_results = await tavily_search_async(
         search_queries=queries,
         max_results=max_results,
@@ -66,7 +69,6 @@ async def tavily_search(
                     "query": response.query,
                 }
 
-    configurable: Configuration = Configuration.from_runnable_config(config)
     summarization_model = (
         _build_chat_model(
             model_name=configurable.summarization_model,
@@ -85,8 +87,21 @@ async def tavily_search(
             raw_content[: configurable.max_content_length],
         )
 
-    summaries = await asyncio.gather(
-        *(summarize_result(result) for result in unique_results.values())
+    gate = get_research_execution_gate(config)
+
+    async def run_summary(result: dict[str, str | None]) -> str | None:
+        try:
+            return await gate.run_summary(lambda: summarize_result(result))
+        except (ExternalServiceException, LangChainException, TimeoutError) as exc:
+            logger.bind(operation="summarize_webpage", error=str(exc)).warning(
+                "summarization_failed"
+            )
+            raw_content = result.get("raw_content")
+            return raw_content[: configurable.max_content_length] if raw_content else None
+
+    summaries = await gather_limited(
+        (lambda result=result: run_summary(result) for result in unique_results.values()),
+        limit=configurable.max_concurrent_summaries,
     )
     if not unique_results:
         return "No valid search results found. Try narrower or different search queries."
@@ -117,38 +132,56 @@ async def tavily_search_async(
     config: RunnableConfig | None = None,
 ) -> list[SearchResponse]:
     """Execute bounded Tavily searches through the shared service client."""
+    configurable = Configuration.from_runnable_config(config)
     http_client = _get_httpx_client_from_config(config)
+    normalized_queries = list(
+        dict.fromkeys(query.strip() for query in search_queries if query.strip())
+    )[: configurable.max_search_queries]
     search_log = logger.bind(
         component="open_deep_search",
         search_api="tavily",
-        queries=len(search_queries),
+        queries=len(normalized_queries),
         max_results=max_results,
         topic=topic,
     )
-    results = await asyncio.gather(
-        *(
-            search(
-                query=query,
-                max_results=max_results,
-                topic=topic,
-                include_answer=False,
-                include_raw_content=include_raw_content,
-                http_client=http_client,
+    gate = get_research_execution_gate(config)
+
+    async def run_query(query: str) -> Any:
+        try:
+            return await gate.run_search(
+                lambda: search(
+                    query=query,
+                    max_results=max_results,
+                    topic=topic,
+                    include_answer=False,
+                    include_raw_content=include_raw_content,
+                    http_client=http_client,
+                )
             )
-            for query in search_queries
-        )
+        except (ExternalServiceException, TimeoutError) as exc:
+            search_log.bind(query_length=len(query), error=str(exc)).warning("tavily_query_failed")
+            return None
+
+    results = await gather_limited(
+        (lambda query=query: run_query(query) for query in normalized_queries),
+        limit=configurable.max_concurrent_search_requests,
     )
     responses: list[SearchResponse] = []
     for result in results:
+        if result is None:
+            continue
         if isinstance(result, Failure):
             error = result.failure()
             search_log.bind(error_code=error.code.value).error(
                 "tavily_search_async_failed", error=error.message
             )
-            raise ExternalServiceException(
-                service="Tavily", detail=error.message, error_code=error.code.value
-            )
+            continue
         responses.append(result.unwrap())
+    if normalized_queries and not responses:
+        raise ExternalServiceException(
+            service="Tavily",
+            detail="All Tavily queries failed",
+        )
     search_log.info("tavily_search_async_complete")
     return responses
 
@@ -162,14 +195,6 @@ def _get_httpx_client_from_config(config: RunnableConfig | None) -> httpx.AsyncC
     if isinstance(http_client, httpx.AsyncClient):
         return http_client
     return None
-
-
-def _get_crawl4ai_crawler_from_config(config: RunnableConfig | None) -> Any:
-    """Read the lifespan-owned Crawl4AI AsyncWebCrawler from RunnableConfig when present."""
-    if not config:
-        return None
-    configurable = config.get("configurable", {})
-    return configurable.get("crawl4ai_crawler")
 
 
 async def summarize_webpage(model: Any, webpage_content: str) -> str:

--- a/src/app/shared/langgraph_layer/open_deep_search/utils.py
+++ b/src/app/shared/langgraph_layer/open_deep_search/utils.py
@@ -79,6 +79,7 @@ async def tavily_search(
     )
 
     async def summarize_result(result: dict[str, str | None]) -> str | None:
+        """Summarize one bounded search result, if raw content is available."""
         raw_content = result.get("raw_content")
         if not raw_content:
             return None
@@ -90,6 +91,7 @@ async def tavily_search(
     gate = get_research_execution_gate(config)
 
     async def run_summary(result: dict[str, str | None]) -> str | None:
+        """Run one summary under the shared gate and preserve raw fallback content."""
         try:
             return await gate.run_summary(lambda: summarize_result(result))
         except (ExternalServiceException, LangChainException, TimeoutError) as exc:
@@ -147,6 +149,7 @@ async def tavily_search_async(
     gate = get_research_execution_gate(config)
 
     async def run_query(query: str) -> Any:
+        """Run one Tavily query and convert expected provider failures to skips."""
         try:
             return await gate.run_search(
                 lambda: search(

--- a/tests/unit/test_open_deep_search_execution.py
+++ b/tests/unit/test_open_deep_search_execution.py
@@ -1,0 +1,146 @@
+"""Concurrency and failure tests for immediate deep research."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from langchain_core.messages import AIMessage
+from returns.result import Failure, Success
+
+from app.shared.langgraph_layer.open_deep_search import utils as open_deep_search_utils
+from app.shared.langgraph_layer.open_deep_search.execution import (
+    ResearchExecutionGate,
+    gather_limited,
+)
+from app.shared.langgraph_layer.open_deep_search.graph import (
+    execute_tool_safely,
+    route_researcher,
+)
+from app.shared.services.errors import TavilyExternalError
+from app.shared.services.tavily import SearchResponse
+from app.utils import ExternalServiceException
+
+
+@pytest.mark.asyncio
+async def test_gather_limited_respects_per_invocation_limit() -> None:
+    active = 0
+    peak = 0
+
+    async def operation(value: int) -> int:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0)
+        active -= 1
+        return value
+
+    values = await gather_limited(
+        (lambda value=value: operation(value) for value in range(8)),
+        limit=2,
+    )
+
+    assert values == list(range(8))
+    assert peak == 2
+
+
+@pytest.mark.asyncio
+async def test_gather_limited_cancels_siblings_after_failure() -> None:
+    sibling_cancelled = False
+
+    async def failing_operation() -> None:
+        await asyncio.sleep(0)
+        msg = "provider failed"
+        raise RuntimeError(msg)
+
+    async def long_operation() -> None:
+        nonlocal sibling_cancelled
+        try:
+            await asyncio.sleep(60)
+        finally:
+            sibling_cancelled = True
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        await gather_limited(
+            (failing_operation, long_operation),
+            limit=2,
+        )
+
+    assert sibling_cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_tavily_queries_are_deduplicated_and_capped(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def fake_search(query: str, **kwargs: object):
+        _ = kwargs
+        calls.append(query)
+        return Success(SearchResponse(query=query, results=[], answer=None, total_results=0))
+
+    monkeypatch.setattr(open_deep_search_utils, "search", fake_search)
+    config = {
+        "configurable": {
+            "max_search_queries": 2,
+            "max_concurrent_search_requests": 1,
+            "research_execution_gate": ResearchExecutionGate(
+                max_concurrent_search_requests=1,
+                max_concurrent_summaries=1,
+            ),
+        }
+    }
+
+    responses = await open_deep_search_utils.tavily_search_async(
+        [" first ", "", "second", "first", "third"],
+        config=config,
+    )
+
+    assert calls == ["first", "second"]
+    assert len(responses) == 2
+
+
+@pytest.mark.asyncio
+async def test_tavily_search_preserves_successes_when_one_query_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_search(query: str, **kwargs: object):
+        _ = kwargs
+        if query == "bad":
+            return Failure(TavilyExternalError(message="upstream failure"))
+        return Success(SearchResponse(query=query, results=[], answer=None, total_results=0))
+
+    monkeypatch.setattr(open_deep_search_utils, "search", fake_search)
+    responses = await open_deep_search_utils.tavily_search_async(
+        ["bad", "good"],
+        config={"configurable": {"max_concurrent_search_requests": 2}},
+    )
+
+    assert [response.query for response in responses] == ["good"]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_safely_turns_provider_failure_into_observation() -> None:
+    class FailingTool:
+        name = "tavily_search"
+
+        async def ainvoke(self, args: dict[str, object], config: object) -> str:
+            _ = (args, config)
+            raise ExternalServiceException(service="Tavily", detail="temporarily unavailable")
+
+    observation = await execute_tool_safely(FailingTool(), {}, {})
+
+    assert observation.startswith("Error executing tool:")
+    assert "temporarily unavailable" in observation
+
+
+def test_unknown_crawl_call_is_handled_by_immediate_tool_executor() -> None:
+    state = {
+        "researcher_messages": [
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "crawl_webpage", "args": {}, "id": "call-1"}],
+            )
+        ]
+    }
+
+    assert route_researcher(state) == "researcher_tools"

--- a/tests/unit/test_open_deep_search_execution.py
+++ b/tests/unit/test_open_deep_search_execution.py
@@ -8,6 +8,7 @@ import pytest
 from langchain_core.messages import AIMessage
 from returns.result import Failure, Success
 
+from app.shared.langgraph_layer.open_deep_search import graph as open_deep_search_graph
 from app.shared.langgraph_layer.open_deep_search import utils as open_deep_search_utils
 from app.shared.langgraph_layer.open_deep_search.execution import (
     ResearchExecutionGate,
@@ -15,6 +16,7 @@ from app.shared.langgraph_layer.open_deep_search.execution import (
 )
 from app.shared.langgraph_layer.open_deep_search.graph import (
     execute_tool_safely,
+    researcher_tools,
     route_researcher,
 )
 from app.shared.services.errors import TavilyExternalError
@@ -131,6 +133,105 @@ async def test_execute_tool_safely_turns_provider_failure_into_observation() -> 
 
     assert observation.startswith("Error executing tool:")
     assert "temporarily unavailable" in observation
+
+
+@pytest.mark.asyncio
+async def test_researcher_tools_caps_recognized_calls_per_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executed: list[str] = []
+
+    class FakeTool:
+        name = "tavily_search"
+
+        async def ainvoke(self, args: dict[str, object], config: object) -> str:
+            _ = config
+            executed.append(str(args["query"]))
+            return f"observed {args['query']}"
+
+    async def fake_get_all_tools(config: object) -> list[FakeTool]:
+        _ = config
+        return [FakeTool()]
+
+    monkeypatch.setattr(open_deep_search_graph, "get_all_tools", fake_get_all_tools)
+    state = {
+        "researcher_messages": [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"name": "tavily_search", "args": {"query": "one"}, "id": "call-1"},
+                    {"name": "tavily_search", "args": {"query": "two"}, "id": "call-2"},
+                ],
+            )
+        ]
+    }
+
+    command = await researcher_tools(
+        state,
+        {
+            "configurable": {
+                "max_tool_calls_per_turn": 1,
+                "max_concurrent_research_tools": 1,
+            }
+        },
+    )
+
+    outputs = command.update["researcher_messages"]
+    assert executed == ["one"]
+    assert [message.content for message in outputs] == [
+        "observed one",
+        "Error: maximum tool calls per turn exceeded. Retry with 1 or fewer tool calls.",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_supervisor_tools_cancels_researcher_siblings_after_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sibling_cancelled = False
+
+    class FakeResearcherSubgraph:
+        async def ainvoke(self, state: dict[str, object], config: object) -> dict[str, object]:
+            nonlocal sibling_cancelled
+            _ = config
+            if state["research_topic"] == "bad":
+                await asyncio.sleep(0)
+                raise RuntimeError("subgraph failed")
+            try:
+                await asyncio.sleep(60)
+            finally:
+                sibling_cancelled = True
+            return {}
+
+    monkeypatch.setattr(open_deep_search_graph, "researcher_subgraph", FakeResearcherSubgraph())
+    state = {
+        "supervisor_messages": [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "ConductResearch",
+                        "args": {"research_topic": "bad"},
+                        "id": "call-1",
+                    },
+                    {
+                        "name": "ConductResearch",
+                        "args": {"research_topic": "long"},
+                        "id": "call-2",
+                    },
+                ],
+            )
+        ],
+        "research_iterations": 1,
+    }
+
+    command = await open_deep_search_graph.supervisor_tools(
+        state,
+        {"configurable": {"max_concurrent_research_units": 2}},
+    )
+
+    assert command.goto == "__end__"
+    assert sibling_cancelled is True
 
 
 def test_unknown_crawl_call_is_handled_by_immediate_tool_executor() -> None:


### PR DESCRIPTION
## Summary

Closes #57.

- Adds process-local capacity gates and per-invocation limits for deep-research tools, Tavily requests, summaries, and query count.
- Caps recognized researcher tool calls per turn and returns overflow calls as explicit observations.
- Cancels and awaits unfinished sibling tasks when bounded fan-out fails, including supervisor researcher-subgraph delegation.
- Preserves successful Tavily results when individual queries fail and caps raw-content fallbacks.
- Converts provider and timeout failures into model-visible observations.
- Removes the unreachable inline `crawl_webpage`/`crawl_executor` graph path. Crawl4AI remains on the durable API/Celery path.
- Keeps tool-call output order and reports unknown tools explicitly.

## Test Coverage

- Added 8 focused tests covering concurrency limits, cancellation cleanup, query deduplication/capping, partial Tavily failures, provider exception translation, and unknown crawl calls.

## Verification Results

- Focused tests: `6 passed`
- Full pytest: `634 passed, 1 failed, 39 deselected`
  - The failure is pre-existing and unrelated: `tests/unit/test_throwaway_graph_resilience.py::test_permanent_failure_is_not_retried`.
- Ruff changed scope: passed.
- Ty changed package: passed.
- Full Ty: retains pre-existing errors in `agents/factory.py`, `middlewares/guardrails.py`, and `callback.py`.
- `ast-grep scan src/`: retains existing crawler-router warnings only.
- `git diff --check`: passed.

## CodeRabbit Review

- Final scoped CodeRabbit CLI review: `0 findings` across all five changed source files.
- An initial unscoped pass also reported findings in unrelated user-owned `.github/skills/OKF/SPEC.md`; those files were not modified.

## Operational Note

The execution gate is process-local. A deployment-wide cap still requires shared Redis admission or worker-level capacity configuration. Durable Crawl4AI jobs continue to use the existing queue and worker ownership model.

## Test plan

- [x] Focused deep-research concurrency tests
- [x] Full pytest executed; one unrelated pre-existing failure documented
- [x] Ruff and changed-package Ty checks
- [x] CodeRabbit CLI review
- [x] ast-grep scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make deep research execution bounded and failure-resilient across provider requests, summaries, tool calls, and delegated research tasks.

Bug Fixes:
- Bound deep-research provider fan-out and per-invocation work to prevent uncontrolled concurrency and failure propagation.
- Preserve partial Tavily results and fall back to truncated raw content when individual searches or summaries fail.
- Expose provider, timeout, unknown-tool, and excess-tool-call failures as model-visible observations.
- Cancel and await sibling research tasks when bounded parallel execution fails.

Enhancements:
- Deduplicate and cap Tavily queries, enforce per-turn researcher tool-call limits, preserve tool-output ordering, and remove the unreachable inline Crawl4AI graph path while retaining durable crawling.

Deployment:
- Document that execution gates are process-local and that deployment-wide provider limits require shared admission control or worker capacity configuration.

Tests:
- Add focused coverage for concurrency limits, cancellation cleanup, query capping and deduplication, partial provider failures, translated exceptions, tool-call limits, and unknown crawl calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controls to limit concurrent research, search, and summarization activity.
  * Search queries are normalized, deduplicated, and capped.
  * Partial search results remain available when individual queries fail.
  * Provider failures and unavailable tools now produce safer, user-visible responses.

* **Bug Fixes**
  * Improved handling of failed or timed-out research operations.
  * Prevented excessive parallel requests during deep research.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->